### PR TITLE
Suppress STDOUT when running specs

### DIFF
--- a/spec/features_spec.rb
+++ b/spec/features_spec.rb
@@ -6,7 +6,7 @@
 
 require "spec_helper"
 
-RSpec.describe "Attr Masker gem" do
+RSpec.describe "Attr Masker gem", :suppress_stdout do
   before do
     stub_const "User", Class.new(ActiveRecord::Base)
 

--- a/spec/support/silence_stdout.rb
+++ b/spec/support/silence_stdout.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before(:each, suppress_stdout: true) do
+    allow(STDOUT).to receive(:write)
+  end
+end


### PR DESCRIPTION
Do not pollute the RSpec output with debug information printed from the Rake task.