### PR TITLE
Code cleanup & useless options deletion

### DIFF
--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -21,22 +21,6 @@ module AttrMasker
   # Options (any other options you specify are passed to the masker's mask
   # methods)
   #
-  #   :attribute        => The name of the referenced masker attribute. For example
-  #                        <tt>attr_accessor :email, :attribute => :ee</tt> would generate an
-  #                        attribute named 'ee' to store the masker email. This is useful when defining
-  #                        one attribute to mask at a time or when the :prefix and :suffix options
-  #                        aren't enough. Defaults to nil.
-  #
-  #   :prefix           => A prefix used to generate the name of the referenced masker attributes.
-  #                        For example <tt>attr_accessor :email, :password, :prefix => 'crypted_'</tt> would
-  #                        generate attributes named 'crypted_email' and 'crypted_password' to store the
-  #                        masker email and password. Defaults to 'masker_'.
-  #
-  #   :suffix           => A suffix used to generate the name of the referenced masker attributes.
-  #                        For example <tt>attr_accessor :email, :password, :prefix => '', :suffix => '_masker'</tt>
-  #                        would generate attributes named 'email_masker' and 'password_masker' to store the
-  #                        masker email. Defaults to ''.
-  #
   #   :key              => The maskion key. This option may not be required if you're using a custom masker. If you pass
   #                        a symbol representing an instance method then the :key option will be replaced with the result of the
   #                        method before being passed to the masker. Objects that respond to :call are evaluated as well (including procs).
@@ -112,8 +96,7 @@ module AttrMasker
     }.merge!(attr_masker_options).merge!(attributes.last.is_a?(Hash) ? attributes.pop : {})
 
     attributes.each do |attribute|
-      masker_attribute_name = (options[:attribute] ? options[:attribute] : [options[:prefix], attribute, options[:suffix]].join).to_sym
-      masker_attributes[attribute.to_sym] = options.merge(:attribute => masker_attribute_name)
+      masker_attributes[attribute.to_sym] = options.merge(attribute: attribute.to_sym)
     end
   end
 

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -3,9 +3,9 @@
 
 # Adds attr_accessors that mask an object's attributes
 module AttrMasker
-  autoload :Version, 'attr_masker/version'
+  autoload :Version, "attr_masker/version"
 
-  require 'attr_masker/railtie' if defined?(Rails)
+  require "attr_masker/railtie" if defined?(Rails)
   def self.extended(base) # :nodoc:
     base.class_eval do
 
@@ -77,10 +77,10 @@ module AttrMasker
       :column_name      => nil,
       :marshal          => false,
       :marshaler        => Marshal,
-      :dump_method      => 'dump',
-      :load_method      => 'load',
+      :dump_method      => "dump",
+      :load_method      => "load",
       :masker           => AttrMasker::Masker,
-      :mask_method      => 'mask',
+      :mask_method      => "mask",
     }.merge!(attr_masker_options).merge!(attributes.last.is_a?(Hash) ? attributes.pop : {})
 
     attributes.each do |attribute|
@@ -176,7 +176,7 @@ module AttrMasker
     # value.
     #
     def self.mask opts
-      '(redacted)'
+      "(redacted)"
     end
   end
 

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -113,26 +113,6 @@ module AttrMasker
 
     attributes.each do |attribute|
       masker_attribute_name = (options[:attribute] ? options[:attribute] : [options[:prefix], attribute, options[:suffix]].join).to_sym
-
-      # instance_methods_as_symbols = instance_methods.collect { |method| method.to_sym }
-      # attr_reader masker_attribute_name unless instance_methods_as_symbols.include?(masker_attribute_name)
-      # attr_writer masker_attribute_name unless instance_methods_as_symbols.include?(:"#{masker_attribute_name}=")
-
-      # define_method(attribute) do
-      #   instance_variable_get("@#{attribute}") ||
-      #     instance_variable_set("@#{attribute}", unmask(attribute, send(masker_attribute_name)))
-      # end
-
-      # define_method("#{attribute}=") do |value|
-      #   send("#{masker_attribute_name}=", mask(attribute, value))
-      #   instance_variable_set("@#{attribute}", value)
-      # end
-
-      # define_method("#{attribute}?") do
-      #   value = send(attribute)
-      #   value.respond_to?(:empty?) ? !value.empty? : !!value
-      # end
-
       masker_attributes[attribute.to_sym] = options.merge(:attribute => masker_attribute_name)
     end
   end

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -26,12 +26,6 @@ module AttrMasker
   #                        method before being passed to the masker. Objects that respond to :call are evaluated as well (including procs).
   #                        Any other key types will be passed directly to the masker.
   #
-  #   :encode           => If set to true, attributes will be encoded as well as masker. This is useful if you're
-  #                        planning on storing the masker attributes in a database. The default encoding is 'm' (base64),
-  #                        however this can be overwritten by setting the :encode option to some other encoding string instead of
-  #                        just 'true'. See http://www.ruby-doc.org/core/classes/Array.html#M002245 for more encoding directives.
-  #                        Defaults to false unless you're using it with ActiveRecord, DataMapper, or Sequel.
-  #
   #   :marshal          => If set to true, attributes will be marshaled as well as masker. This is useful if you're planning
   #                        on masking something other than a string. Defaults to false unless you're using it with ActiveRecord
   #                        or DataMapper.
@@ -58,7 +52,7 @@ module AttrMasker
   #
   #   class User
   #     # now all attributes will be encoded and marshaled by default
-  #     attr_masker_options.merge!(:encode => true, :marshal => true, :some_other_option => true)
+  #     attr_masker_options.merge!(:marshal => true, :some_other_option => true)
   #     attr_masker :configuration, :key => 'my secret key'
   #   end
   #
@@ -85,7 +79,6 @@ module AttrMasker
     options = {
       :if               => true,
       :unless           => false,
-      :encode           => false,
       :column_name      => nil,
       :marshal          => false,
       :marshaler        => Marshal,

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -21,11 +21,6 @@ module AttrMasker
   # Options (any other options you specify are passed to the masker's mask
   # methods)
   #
-  #   :key              => The maskion key. This option may not be required if you're using a custom masker. If you pass
-  #                        a symbol representing an instance method then the :key option will be replaced with the result of the
-  #                        method before being passed to the masker. Objects that respond to :call are evaluated as well (including procs).
-  #                        Any other key types will be passed directly to the masker.
-  #
   #   :marshal          => If set to true, attributes will be marshaled as well as masker. This is useful if you're planning
   #                        on masking something other than a string. Defaults to false unless you're using it with ActiveRecord
   #                        or DataMapper.
@@ -53,15 +48,15 @@ module AttrMasker
   #   class User
   #     # now all attributes will be encoded and marshaled by default
   #     attr_masker_options.merge!(:marshal => true, :some_other_option => true)
-  #     attr_masker :configuration, :key => 'my secret key'
+  #     attr_masker :configuration
   #   end
   #
   #
   # Example
   #
   #   class User
-  #     attr_masker :email, :credit_card, :key => 'some secret key'
-  #     attr_masker :configuration, :key => 'some other secret key', :marshal => true
+  #     attr_masker :email, :credit_card
+  #     attr_masker :configuration, :marshal => true
   #   end
   #
   #   @user = User.new
@@ -147,10 +142,10 @@ module AttrMasker
   # Example
   #
   #   class User
-  #     attr_masker :email, :key => 'my secret key'
+  #     attr_masker :email
   #   end
   #
-  #   User.masker_attributes # { :email => { :attribute => 'masker_email', :key => 'my secret key' } }
+  #   User.masker_attributes # { :email => { :attribute => 'masker_email' } }
   def masker_attributes
     @masker_attributes ||= superclass.masker_attributes.dup
   end
@@ -161,7 +156,7 @@ module AttrMasker
   # Example
   #
   #   class User
-  #     attr_masker :email, :key => 'my secret key'
+  #     attr_masker :email
   #   end
   #
   #   User.mask_email('SOME_masker_EMAIL_STRING')
@@ -213,7 +208,7 @@ module AttrMasker
     #
     #  class User
     #    attr_accessor :secret_key
-    #    attr_masker :email, :key => :secret_key
+    #    attr_masker :email
     #
     #    def initialize(secret_key)
     #      self.secret_key = secret_key

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -31,9 +31,9 @@ module AttrMasker
   #
   #   :load_method      => The load method name to call on the <tt>:marshaler</tt> object. Defaults to 'load'.
   #
-  #   :masker        => The object to use for masking. Defaults to Masker.
+  #   :masker           => The object to use for masking. Defaults to Masker.
   #
-  #   :mask_method   => The mask method name to call on the <tt>:masker</tt> object. Defaults to 'mask'.
+  #   :mask_method      => The mask method name to call on the <tt>:masker</tt> object. Defaults to 'mask'.
   #
   #   :if               => Attributes are only masker if this option evaluates to true. If you pass a symbol representing an instance
   #                        method then the result of the method will be evaluated. Any objects that respond to <tt>:call</tt> are evaluated as well.


### PR DESCRIPTION
Cleaning-up the code base. Some last traces of :attribute, :prefix, :suffix, :encode, and :key options are being removed now. They were useful in Attr Encrypted gem but make little sense in Attr Masker.