### PR TITLE
Maskers respond to #call

### DIFF
--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -131,7 +131,6 @@ module AttrMasker
     # if options[:if] && !options[:unless] && !value.nil? && !(value.is_a?(String) && value.empty?)
     if options[:if] && !options[:unless]
       value = options[:marshal] ? options[:marshaler].send(options[:dump_method], value) : value.to_s
-      # masker_value = options[:masker].send(options[:mask_method], options.merge!(:value => value))
       masker_value = options[:masker].send(options[:mask_method], options.merge!(:value => value))
       masker_value
     else

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -128,7 +128,7 @@ module AttrMasker
     # if options[:if] && !options[:unless] && !value.nil? && !(value.is_a?(String) && value.empty?)
     if options[:if] && !options[:unless]
       value = options[:marshal] ? options[:marshaler].send(options[:dump_method], value) : value.to_s
-      masker_value = options[:masker].call(options.merge!(:value => value))
+      masker_value = options[:masker].call(options.merge!(value: value))
       masker_value
     else
       value

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -5,6 +5,10 @@
 module AttrMasker
   autoload :Version, "attr_masker/version"
 
+  module Maskers
+    autoload :Simple, "attr_masker/maskers/simple"
+  end
+
   require "attr_masker/railtie" if defined?(Rails)
   def self.extended(base) # :nodoc:
     base.class_eval do
@@ -31,7 +35,7 @@ module AttrMasker
   #
   #   :load_method      => The load method name to call on the <tt>:marshaler</tt> object. Defaults to 'load'.
   #
-  #   :masker           => The object to use for masking. Defaults to Masker.
+  #   :masker           => The object to use for masking. Defaults to AttrMasker::Maskers::Simple.
   #
   #   :mask_method      => The mask method name to call on the <tt>:masker</tt> object. Defaults to 'mask'.
   #
@@ -79,7 +83,7 @@ module AttrMasker
       :marshaler        => Marshal,
       :dump_method      => "dump",
       :load_method      => "load",
-      :masker           => AttrMasker::Masker,
+      :masker           => AttrMasker::Maskers::Simple,
       :mask_method      => "mask",
     }.merge!(attr_masker_options).merge!(attributes.last.is_a?(Hash) ? attributes.pop : {})
 
@@ -165,18 +169,6 @@ module AttrMasker
       send(:mask, $1, *arguments)
     else
       super
-    end
-  end
-
-  class Masker
-
-    # This default masker simply replaces any value with a fixed string.
-    #
-    # +opts+ is a Hash with the key :value that gives you the current attribute
-    # value.
-    #
-    def self.mask opts
-      "(redacted)"
     end
   end
 

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -84,7 +84,7 @@ module AttrMasker
       :dump_method      => "dump",
       :load_method      => "load",
       :masker           => AttrMasker::Maskers::Simple,
-      :mask_method      => "mask",
+      :mask_method      => "call",
     }.merge!(attr_masker_options).merge!(attributes.last.is_a?(Hash) ? attributes.pop : {})
 
     attributes.each do |attribute|

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -35,9 +35,7 @@ module AttrMasker
   #
   #   :load_method      => The load method name to call on the <tt>:marshaler</tt> object. Defaults to 'load'.
   #
-  #   :masker           => The object to use for masking. Defaults to AttrMasker::Maskers::Simple.
-  #
-  #   :mask_method      => The mask method name to call on the <tt>:masker</tt> object. Defaults to 'mask'.
+  #   :masker           => The object to use for masking. It must respond to +#mask+. Defaults to AttrMasker::Maskers::Simple.
   #
   #   :if               => Attributes are only masker if this option evaluates to true. If you pass a symbol representing an instance
   #                        method then the result of the method will be evaluated. Any objects that respond to <tt>:call</tt> are evaluated as well.
@@ -84,7 +82,6 @@ module AttrMasker
       :dump_method      => "dump",
       :load_method      => "load",
       :masker           => AttrMasker::Maskers::SIMPLE,
-      :mask_method      => "call",
     }.merge!(attr_masker_options).merge!(attributes.last.is_a?(Hash) ? attributes.pop : {})
 
     attributes.each do |attribute|
@@ -131,7 +128,7 @@ module AttrMasker
     # if options[:if] && !options[:unless] && !value.nil? && !(value.is_a?(String) && value.empty?)
     if options[:if] && !options[:unless]
       value = options[:marshal] ? options[:marshaler].send(options[:dump_method], value) : value.to_s
-      masker_value = options[:masker].send(options[:mask_method], options.merge!(:value => value))
+      masker_value = options[:masker].call(options.merge!(:value => value))
       masker_value
     else
       value

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -220,7 +220,11 @@ module AttrMasker
       # XXX:Keep
       def evaluated_attr_masker_options_for(attribute)
         self.class.masker_attributes[attribute.to_sym].inject({}) do |hash, (option, value)|
-          hash.merge!(option => evaluate_attr_masker_option(value))
+          if %i[if unless].include?(option)
+            hash.merge!(option => evaluate_attr_masker_option(value))
+          else
+            hash.merge!(option => value)
+          end
         end
       end
 

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -6,7 +6,7 @@ module AttrMasker
   autoload :Version, "attr_masker/version"
 
   module Maskers
-    autoload :Simple, "attr_masker/maskers/simple"
+    autoload :SIMPLE, "attr_masker/maskers/simple"
   end
 
   require "attr_masker/railtie" if defined?(Rails)
@@ -83,7 +83,7 @@ module AttrMasker
       :marshaler        => Marshal,
       :dump_method      => "dump",
       :load_method      => "load",
-      :masker           => AttrMasker::Maskers::Simple,
+      :masker           => AttrMasker::Maskers::SIMPLE,
       :mask_method      => "call",
     }.merge!(attr_masker_options).merge!(attributes.last.is_a?(Hash) ? attributes.pop : {})
 

--- a/lib/attr_masker/maskers/simple.rb
+++ b/lib/attr_masker/maskers/simple.rb
@@ -5,11 +5,8 @@ module AttrMasker
     # +opts+ is a Hash with the key :value that gives you the current attribute
     # value.
     #
-    class Simple
-
-      def self.call opts
-        "(redacted)"
-      end
+    SIMPLE = lambda do |_opts|
+      "(redacted)"
     end
   end
 end

--- a/lib/attr_masker/maskers/simple.rb
+++ b/lib/attr_masker/maskers/simple.rb
@@ -1,0 +1,15 @@
+module AttrMasker
+  module Maskers
+    # This default masker simply replaces any value with a fixed string.
+    #
+    # +opts+ is a Hash with the key :value that gives you the current attribute
+    # value.
+    #
+    class Simple
+
+      def self.mask opts
+        "(redacted)"
+      end
+    end
+  end
+end

--- a/lib/attr_masker/maskers/simple.rb
+++ b/lib/attr_masker/maskers/simple.rb
@@ -7,7 +7,7 @@ module AttrMasker
     #
     class Simple
 
-      def self.mask opts
+      def self.call opts
         "(redacted)"
       end
     end

--- a/spec/features_spec.rb
+++ b/spec/features_spec.rb
@@ -149,19 +149,17 @@ RSpec.describe "Attr Masker gem", :suppress_stdout do
   end
 
   example "Using a custom masker" do
-    custom_masker = Object.new
-
-    def custom_masker.call(value:, **_)
+    reverse_masker = ->(value:, **_) do
       value.reverse
     end
 
-    def custom_masker.upcase(value:, **_)
+    upcase_masker = ->(value:, **_) do
       value.upcase
     end
 
     User.class_eval do
-      attr_masker :first_name, masker: custom_masker
-      attr_masker :last_name, masker: custom_masker, mask_method: :upcase
+      attr_masker :first_name, masker: reverse_masker
+      attr_masker :last_name, masker: upcase_masker
     end
 
     expect { run_rake_task }.not_to(change { User.count })

--- a/spec/features_spec.rb
+++ b/spec/features_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe "Attr Masker gem", :suppress_stdout do
   example "Using a custom masker" do
     custom_masker = Object.new
 
-    def custom_masker.mask(value:, **_)
+    def custom_masker.call(value:, **_)
       value.reverse
     end
 

--- a/spec/maskers/simple_spec.rb
+++ b/spec/maskers/simple_spec.rb
@@ -8,7 +8,7 @@ require "spec_helper"
 RSpec.describe AttrMasker::Maskers::Simple do
   subject { described_class }
 
-  example { expect(subject.mask(value: "Solo")).to eq("(redacted)") }
-  example { expect(subject.mask(value: Math::PI)).to eq("(redacted)") }
-  example { expect(subject.mask(value: nil)).to eq("(redacted)") }
+  example { expect(subject.(value: "Solo")).to eq("(redacted)") }
+  example { expect(subject.(value: Math::PI)).to eq("(redacted)") }
+  example { expect(subject.(value: nil)).to eq("(redacted)") }
 end

--- a/spec/maskers/simple_spec.rb
+++ b/spec/maskers/simple_spec.rb
@@ -5,7 +5,7 @@
 
 require "spec_helper"
 
-RSpec.describe AttrMasker::Maskers::Simple do
+RSpec.describe AttrMasker::Maskers::SIMPLE do
   subject { described_class }
 
   example { expect(subject.(value: "Solo")).to eq("(redacted)") }

--- a/spec/maskers/simple_spec.rb
+++ b/spec/maskers/simple_spec.rb
@@ -1,0 +1,14 @@
+# (c) 2017 Ribose Inc.
+#
+
+# No point in using ApplicationRecord here.
+
+require "spec_helper"
+
+RSpec.describe AttrMasker::Maskers::Simple do
+  subject { described_class }
+
+  example { expect(subject.mask(value: "Solo")).to eq("(redacted)") }
+  example { expect(subject.mask(value: Math::PI)).to eq("(redacted)") }
+  example { expect(subject.mask(value: nil)).to eq("(redacted)") }
+end


### PR DESCRIPTION
1. Extract the existing masker into a separate file, rework it, add tests.
2. Change the standard masker method from #mask to #call.
3. Improve the implementation of the default masker.
4. Delete support for the :mask_method options.