### PR TITLE
Fix dependencies for the upstream Rails builds

### DIFF
--- a/gemfiles/Rails-head.gemfile
+++ b/gemfiles/Rails-head.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "activerecord", github: "rails/rails"
+gem "arel", github: "rails/arel"
 
 gemspec path: ".."


### PR DESCRIPTION
HEAD ActiveRecord typically requires HEAD Arel.  Travis builds are currently broken cause being run with the released Arel version.