### PR TITLE
Implement replacing masker, enhance documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -90,6 +90,26 @@ A hash is passed as an argument, which includes some information about the
 record being masked and the attribute value.  It can be used to further
 customize masker's behaviour.
 
+=== Built-in maskers
+
+Attr Masker comes with several built-in maskers.
+
+`AttrMasker::Maskers::SIMPLE`::
++
+Simply replaces any value with the `"(redacted)"`.  Only useful for columns
+containing textual data.
++
+This is a default masker.  It is used when `:masker` option is unspecified.
++
+Example:
++
+[source,ruby]
+----
+attr_masker :first_name
+attr_masker :last_name, :masker => AttrMasker::Maskers::SIMPLE
+----
++ Would set both `first_name` and `last_name` attributes to `"(redacted)"`.
+
 == Roadmap & TODOs
 - documentation
 - spec tests

--- a/README.adoc
+++ b/README.adoc
@@ -110,6 +110,28 @@ attr_masker :last_name, :masker => AttrMasker::Maskers::SIMPLE
 ----
 + Would set both `first_name` and `last_name` attributes to `"(redacted)"`.
 
+`AttrMasker::Maskers::Replacing`::
++
+Replaces characters with some masker string (single asterisk by default).
+Can be initialized with options.
++
+[options="header"]
+|===============================================================================
+|Name|Default|Description
+|`replacement`|`"*"`|Replacement string, can be empty.
+|`alphanum_only`|`false`|When true, only alphanumeric charaters are replaced.
+|===============================================================================
++
+Example:
++
+[source,ruby]
+----
+rm = AttrMasker::Maskers::Replacing.new(character: "X", alphanum_only: true)
+attr_masker :phone, :masker => rm
+----
++
+Would mask "123-456-7890" as "XXX-XXX-XXXX".
+
 == Roadmap & TODOs
 - documentation
 - spec tests

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -6,6 +6,7 @@ module AttrMasker
   autoload :Version, "attr_masker/version"
 
   module Maskers
+    autoload :Replacing, "attr_masker/maskers/replacing"
     autoload :SIMPLE, "attr_masker/maskers/simple"
   end
 

--- a/lib/attr_masker/maskers/replacing.rb
+++ b/lib/attr_masker/maskers/replacing.rb
@@ -1,0 +1,30 @@
+# (c) 2017 Ribose Inc.
+#
+module AttrMasker
+  module Maskers
+    # This default masker simply replaces any value with a fixed string.
+    #
+    # +opts+ is a Hash with the key :value that gives you the current attribute
+    # value.
+    #
+    class Replacing
+      attr_reader :replacement, :alphanum_only
+
+      def initialize(replacement: "*", alphanum_only: false)
+        replacement = "" if replacement.nil?
+        @replacement = replacement
+        @alphanum_only = alphanum_only
+      end
+
+      def call(value:, **_opts)
+        return value unless value.is_a? String
+
+        if alphanum_only
+          value.gsub(/[[:alnum:]]/, replacement)
+        else
+          replacement * value.size
+        end
+      end
+    end
+  end
+end

--- a/spec/maskers/replacing_spec.rb
+++ b/spec/maskers/replacing_spec.rb
@@ -1,0 +1,48 @@
+# (c) 2017 Ribose Inc.
+#
+
+# No point in using ApplicationRecord here.
+
+require "spec_helper"
+
+RSpec.describe AttrMasker::Maskers::Replacing do
+  subject { described_class.new **options }
+
+  let(:address) { "1 Pedder Street, Hong Kong" }
+
+  shared_examples "AttrMasker::Maskers::Replacing examples" do
+    example { expect(subject.(value: address)).to eq(expected_masked_address) }
+    example { expect(subject.(value: Math::PI)).to eq(Math::PI) }
+    example { expect(subject.(value: nil)).to eq(nil) }
+  end
+
+  context "with default options" do
+    let(:options) { {} }
+    let(:expected_masked_address) { "**************************" }
+    include_examples "AttrMasker::Maskers::Replacing examples"
+  end
+
+  context "with alphanum_only option set to true" do
+    let(:options) { { alphanum_only: true } }
+    let(:expected_masked_address) { "* ****** ******, **** ****" }
+    include_examples "AttrMasker::Maskers::Replacing examples"
+  end
+
+  context "with a custom replacement string" do
+    let(:options) { { replacement: "X" } }
+    let(:expected_masked_address) { "XXXXXXXXXXXXXXXXXXXXXXXXXX" }
+    include_examples "AttrMasker::Maskers::Replacing examples"
+  end
+
+  context "with an empty replacement string" do
+    let(:options) { { replacement: "" } }
+    let(:expected_masked_address) { "" }
+    include_examples "AttrMasker::Maskers::Replacing examples"
+  end
+
+  context "with alphanum_only and replacement options combined" do
+    let(:options) { { alphanum_only: true, replacement: "X" } }
+    let(:expected_masked_address) { "X XXXXXX XXXXXX, XXXX XXXX" }
+    include_examples "AttrMasker::Maskers::Replacing examples"
+  end
+end


### PR DESCRIPTION
Implement replacing master, a first built-in masker which is configurable, enhance documentation about built-in maskers.