### PR TITLE
Disable check for trailing comma in feature specs

### DIFF
--- a/spec/features_spec.rb
+++ b/spec/features_spec.rb
@@ -4,6 +4,9 @@
 # No point in using ApplicationRecord here.
 # rubocop:disable Rails/ApplicationRecord
 
+# No point in ensuring a trailing comma in multiline argument lists here.
+# rubocop:disable Style/TrailingCommaInArguments
+
 require "spec_helper"
 
 RSpec.describe "Attr Masker gem", :suppress_stdout do


### PR DESCRIPTION
In specs, multiline argument lists typically come from compound expectation, e.g.

```ruby
expect(sth) to(
  assertion1 &
  assertion2
)
```

Adding a trailing comma after the last (and only) argument is pointless and actually makes code less readable and maintainable.