### PR TITLE
Move the masking logic to newly-created Attribute class

### DIFF
--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -171,7 +171,7 @@ module AttrMasker
     def mask(attribute_name, value=nil)
       value = self.send(attribute_name) if value.nil?
       attribute = self.class.masker_attributes[attribute_name.to_sym]
-      options = evaluated_attr_masker_options_for(attribute_name)
+      options = attribute.options
       if attribute.should_mask?(self)
         value = attribute.unmarshal_data(value)
         masker_value = options[:masker].call(options.merge!(value: value))
@@ -180,21 +180,6 @@ module AttrMasker
         value
       end
     end
-
-    protected
-
-      # Returns attr_masker options evaluated in the current object's scope for the attribute specified
-      # XXX:Keep
-      def evaluated_attr_masker_options_for(attribute_name)
-        attribute = self.class.masker_attributes[attribute_name.to_sym]
-        attribute.options.inject({}) do |hash, (option, value)|
-          if %i[if unless].include?(option)
-            hash.merge!(option => attribute.evaluate_option(option, self))
-          else
-            hash.merge!(option => value)
-          end
-        end
-      end
   end
 end
 

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -133,9 +133,9 @@ module AttrMasker
     options = attribute.options.merge(options)
     # if options[:if] && !options[:unless] && !value.nil? && !(value.is_a?(String) && value.empty?)
     if options[:if] && !options[:unless]
-      value = options[:marshal] ? options[:marshaler].send(options[:load_method], value) : value
+      value = attribute.unmarshal_data(value)
       masker_value = options[:masker].call(options.merge!(value: value))
-      options[:marshal] ? options[:marshaler].send(options[:dump_method], masker_value) : masker_value
+      attribute.marshal_data(masker_value)
     else
       value
     end

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -17,9 +17,6 @@ module AttrMasker
   require "attr_masker/railtie" if defined?(Rails)
   def self.extended(base) # :nodoc:
     base.class_eval do
-
-      # Only include the dangerous instance methods during the Rake task!
-      include InstanceMethods
       attr_writer :attr_masker_options
       @attr_masker_options, @masker_attributes = {}, {}
     end
@@ -131,25 +128,6 @@ module AttrMasker
   #   User.masker_attributes # { :email => { :attribute => 'masker_email' } }
   def masker_attributes
     @masker_attributes ||= superclass.masker_attributes.dup
-  end
-
-  module InstanceMethods
-
-    # masks a value for the attribute specified using options evaluated in the current object's scope
-    #
-    # Example
-    #
-    #  class User
-    #    attr_accessor :secret_key
-    #    attr_masker :email
-    #
-    #    def initialize(secret_key)
-    #      self.secret_key = secret_key
-    #    end
-    #  end
-    #
-    #  @user = User.new('some-secret-key')
-    #  @user.mask(:email, 'test@example.com')
   end
 end
 

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -191,9 +191,9 @@ module AttrMasker
     #
     #  @user = User.new('some-secret-key')
     #  @user.mask(:email, 'test@example.com')
-    def mask(attribute, value=nil)
-      value = self.send(attribute) if value.nil?
-      self.class.mask(attribute, value, evaluated_attr_masker_options_for(attribute))
+    def mask(attribute_name, value=nil)
+      value = self.send(attribute_name) if value.nil?
+      self.class.mask(attribute_name, value, evaluated_attr_masker_options_for(attribute_name))
     end
 
     protected

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -133,24 +133,6 @@ module AttrMasker
     @masker_attributes ||= superclass.masker_attributes.dup
   end
 
-  # Forwards calls to :mask_#{attribute} to the corresponding mask method
-  # if attribute was configured with attr_masker
-  #
-  # Example
-  #
-  #   class User
-  #     attr_masker :email
-  #   end
-  #
-  #   User.mask_email('SOME_masker_EMAIL_STRING')
-  def method_missing(method, *arguments, &block)
-    if method.to_s =~ /^mask_(.+)$/ && attr_masker?($1)
-      send(:mask, $1, *arguments)
-    else
-      super
-    end
-  end
-
   module InstanceMethods
 
     # masks a value for the attribute specified using options evaluated in the current object's scope
@@ -168,14 +150,6 @@ module AttrMasker
     #
     #  @user = User.new('some-secret-key')
     #  @user.mask(:email, 'test@example.com')
-    def mask(attribute_name)
-      value = self.send(attribute_name)
-      attribute = self.class.masker_attributes[attribute_name.to_sym]
-      options = attribute.options
-      value = attribute.unmarshal_data(value)
-      masker_value = options[:masker].call(options.merge!(value: value))
-      attribute.marshal_data(masker_value)
-    end
   end
 end
 

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -204,24 +204,10 @@ module AttrMasker
         attribute = self.class.masker_attributes[attribute_name.to_sym]
         attribute.options.inject({}) do |hash, (option, value)|
           if %i[if unless].include?(option)
-            hash.merge!(option => evaluate_attr_masker_option(value))
+            hash.merge!(option => attribute.evaluate_option(option, self))
           else
             hash.merge!(option => value)
           end
-        end
-      end
-
-      # Evaluates symbol (method reference) or proc (responds to call) options
-      # XXX:Keep
-      #
-      # If the option is not a symbol or proc then the original option is returned
-      def evaluate_attr_masker_option(option)
-        if option.is_a?(Symbol) && respond_to?(option)
-          send(option)
-        elsif option.respond_to?(:call)
-          option.call(self)
-        else
-          option
         end
       end
   end

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -129,7 +129,8 @@ module AttrMasker
   #
   #   masker_email = User.mask(:email, 'test@example.com')
   def mask(attribute, value, options = {})
-    options = masker_attributes[attribute.to_sym].options.merge(options)
+    attribute = masker_attributes[attribute.to_sym]
+    options = attribute.options.merge(options)
     # if options[:if] && !options[:unless] && !value.nil? && !(value.is_a?(String) && value.empty?)
     if options[:if] && !options[:unless]
       value = options[:marshal] ? options[:marshaler].send(options[:load_method], value) : value
@@ -199,8 +200,9 @@ module AttrMasker
 
       # Returns attr_masker options evaluated in the current object's scope for the attribute specified
       # XXX:Keep
-      def evaluated_attr_masker_options_for(attribute)
-        self.class.masker_attributes[attribute.to_sym].options.inject({}) do |hash, (option, value)|
+      def evaluated_attr_masker_options_for(attribute_name)
+        attribute = self.class.masker_attributes[attribute_name.to_sym]
+        attribute.options.inject({}) do |hash, (option, value)|
           if %i[if unless].include?(option)
             hash.merge!(option => evaluate_attr_masker_option(value))
           else

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -172,7 +172,7 @@ module AttrMasker
       value = self.send(attribute_name) if value.nil?
       attribute = self.class.masker_attributes[attribute_name.to_sym]
       options = evaluated_attr_masker_options_for(attribute_name)
-      if options[:if] && !options[:unless]
+      if attribute.should_mask?(self)
         value = attribute.unmarshal_data(value)
         masker_value = options[:masker].call(options.merge!(value: value))
         attribute.marshal_data(masker_value)

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -168,8 +168,8 @@ module AttrMasker
     #
     #  @user = User.new('some-secret-key')
     #  @user.mask(:email, 'test@example.com')
-    def mask(attribute_name, value=nil)
-      value = self.send(attribute_name) if value.nil?
+    def mask(attribute_name)
+      value = self.send(attribute_name)
       attribute = self.class.masker_attributes[attribute_name.to_sym]
       options = attribute.options
       if attribute.should_mask?(self)

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -131,7 +131,6 @@ module AttrMasker
   def mask(attribute, value, options = {})
     attribute = masker_attributes[attribute.to_sym]
     options = attribute.options.merge(options)
-    # if options[:if] && !options[:unless] && !value.nil? && !(value.is_a?(String) && value.empty?)
     if options[:if] && !options[:unless]
       value = attribute.unmarshal_data(value)
       masker_value = options[:masker].call(options.merge!(value: value))

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -172,13 +172,9 @@ module AttrMasker
       value = self.send(attribute_name)
       attribute = self.class.masker_attributes[attribute_name.to_sym]
       options = attribute.options
-      if attribute.should_mask?(self)
-        value = attribute.unmarshal_data(value)
-        masker_value = options[:masker].call(options.merge!(value: value))
-        attribute.marshal_data(masker_value)
-      else
-        value
-      end
+      value = attribute.unmarshal_data(value)
+      masker_value = options[:masker].call(options.merge!(value: value))
+      attribute.marshal_data(masker_value)
     end
   end
 end

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -118,27 +118,6 @@ module AttrMasker
     masker_attributes.has_key?(attribute.to_sym)
   end
 
-  # masks a value for the attribute specified
-  # XXX:modify
-  #
-  # Example
-  #
-  #   class User
-  #     attr_masker :email
-  #   end
-  #
-  #   masker_email = User.mask(:email, 'test@example.com')
-  def mask(attribute, value, options = {})
-    attribute = masker_attributes[attribute.to_sym]
-    if options[:if] && !options[:unless]
-      value = attribute.unmarshal_data(value)
-      masker_value = options[:masker].call(options.merge!(value: value))
-      attribute.marshal_data(masker_value)
-    else
-      value
-    end
-  end
-
   # Contains a hash of masker attributes with virtual attribute names as keys
   # and their corresponding options as values
   # XXX:Keep
@@ -191,7 +170,15 @@ module AttrMasker
     #  @user.mask(:email, 'test@example.com')
     def mask(attribute_name, value=nil)
       value = self.send(attribute_name) if value.nil?
-      self.class.mask(attribute_name, value, evaluated_attr_masker_options_for(attribute_name))
+      attribute = self.class.masker_attributes[attribute_name.to_sym]
+      options = evaluated_attr_masker_options_for(attribute_name)
+      if options[:if] && !options[:unless]
+        value = attribute.unmarshal_data(value)
+        masker_value = options[:masker].call(options.merge!(value: value))
+        attribute.marshal_data(masker_value)
+      else
+        value
+      end
     end
 
     protected

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -130,7 +130,6 @@ module AttrMasker
   #   masker_email = User.mask(:email, 'test@example.com')
   def mask(attribute, value, options = {})
     attribute = masker_attributes[attribute.to_sym]
-    options = attribute.options.merge(options)
     if options[:if] && !options[:unless]
       value = attribute.unmarshal_data(value)
       masker_value = options[:masker].call(options.merge!(value: value))

--- a/lib/attr_masker/attribute.rb
+++ b/lib/attr_masker/attribute.rb
@@ -27,6 +27,16 @@ module AttrMasker
       end
     end
 
+    def marshal_data(data)
+      return data unless options[:marshal]
+      options[:marshaler].send(options[:dump_method], data)
+    end
+
+    def unmarshal_data(data)
+      return data unless options[:marshal]
+      options[:marshaler].send(options[:load_method], data)
+    end
+
     def column_name
       options[:column_name] || name
     end

--- a/lib/attr_masker/attribute.rb
+++ b/lib/attr_masker/attribute.rb
@@ -11,5 +11,9 @@ module AttrMasker
       @model = model
       @options = options
     end
+
+    def column_name
+      options[:column_name] || name
+    end
   end
 end

--- a/lib/attr_masker/attribute.rb
+++ b/lib/attr_masker/attribute.rb
@@ -12,6 +12,16 @@ module AttrMasker
       @options = options
     end
 
+    # Evaluates the +:if+ and +:unless+ attribute options on given instance.
+    # Returns +true+ or +fasle+, depending on whether the attribute should be
+    # masked for this object or not.
+    def should_mask?(model_instance)
+      not (
+        options.key?(:if) && !evaluate_option(:if, model_instance) ||
+        options.key?(:unless) && evaluate_option(:unless, model_instance)
+      )
+    end
+
     # Evaluates option (typically +:if+ or +:unless+) on given model instance.
     # That option can be either a proc (a model is passed as an only argument),
     # or a symbol (a method of that name is called on model instance).

--- a/lib/attr_masker/attribute.rb
+++ b/lib/attr_masker/attribute.rb
@@ -1,0 +1,15 @@
+# (c) 2017 Ribose Inc.
+#
+
+module AttrMasker
+  # Holds the definition of maskable attribute.
+  class Attribute
+    attr_reader :name, :model, :options
+
+    def initialize(name, model, options)
+      @name = name.to_sym
+      @model = model
+      @options = options
+    end
+  end
+end

--- a/lib/attr_masker/attribute.rb
+++ b/lib/attr_masker/attribute.rb
@@ -22,6 +22,22 @@ module AttrMasker
       )
     end
 
+    # Mask the attribute on given model.  Masking will be performed regardless
+    # of +:if+ and +:unless+ options.  A +should_mask?+ method should be called
+    # separately to ensure that given object is eligible for masking.
+    #
+    # The method returns the masked value but does not modify the object's
+    # attribute.
+    #
+    # If +marshal+ attribute's option is +true+, the attribute value will be
+    # loaded before masking, and dumped to proper storage format prior
+    # returning.
+    def mask(model_instance)
+      value = unmarshal_data(model_instance.send(name))
+      masker_value = options[:masker].call(options.merge!(value: value))
+      marshal_data(masker_value)
+    end
+
     # Evaluates option (typically +:if+ or +:unless+) on given model instance.
     # That option can be either a proc (a model is passed as an only argument),
     # or a symbol (a method of that name is called on model instance).

--- a/lib/attr_masker/attribute.rb
+++ b/lib/attr_masker/attribute.rb
@@ -12,6 +12,21 @@ module AttrMasker
       @options = options
     end
 
+    # Evaluates option (typically +:if+ or +:unless+) on given model instance.
+    # That option can be either a proc (a model is passed as an only argument),
+    # or a symbol (a method of that name is called on model instance).
+    def evaluate_option(option_name, model_instance)
+      option = options[option_name]
+
+      if option.is_a?(Symbol)
+        model_instance.send(option)
+      elsif option.respond_to?(:call)
+        option.call(model_instance)
+      else
+        option
+      end
+    end
+
     def column_name
       options[:column_name] || name
     end

--- a/lib/attr_masker/performer.rb
+++ b/lib/attr_masker/performer.rb
@@ -36,9 +36,9 @@ module AttrMasker
       def mask_object(instance)
         klass = instance.class
 
-        updates = klass.masker_attributes.reduce({}) do |acc, masker_attr|
-          attr_name = masker_attr[0]
-          column_name = masker_attr[1].column_name
+        updates = klass.masker_attributes.values.reduce({}) do |acc, attribute|
+          attr_name = attribute.name
+          column_name = attribute.column_name
           masker_value = instance.mask(attr_name)
           acc.merge!(column_name => masker_value)
         end

--- a/lib/attr_masker/performer.rb
+++ b/lib/attr_masker/performer.rb
@@ -38,7 +38,7 @@ module AttrMasker
 
         updates = klass.masker_attributes.reduce({}) do |acc, masker_attr|
           attr_name = masker_attr[0]
-          column_name = masker_attr[1][:column_name] || attr_name
+          column_name = masker_attr[1].options[:column_name] || attr_name
           masker_value = instance.mask(attr_name)
           acc.merge!(column_name => masker_value)
         end

--- a/lib/attr_masker/performer.rb
+++ b/lib/attr_masker/performer.rb
@@ -39,9 +39,8 @@ module AttrMasker
         updates = klass.masker_attributes.values.reduce({}) do |acc, attribute|
           next acc unless attribute.should_mask?(instance)
 
-          attr_name = attribute.name
           column_name = attribute.column_name
-          masker_value = instance.mask(attr_name)
+          masker_value = attribute.mask(instance)
           acc.merge!(column_name => masker_value)
         end
 

--- a/lib/attr_masker/performer.rb
+++ b/lib/attr_masker/performer.rb
@@ -38,7 +38,7 @@ module AttrMasker
 
         updates = klass.masker_attributes.reduce({}) do |acc, masker_attr|
           attr_name = masker_attr[0]
-          column_name = masker_attr[1].options[:column_name] || attr_name
+          column_name = masker_attr[1].column_name
           masker_value = instance.mask(attr_name)
           acc.merge!(column_name => masker_value)
         end

--- a/lib/attr_masker/performer.rb
+++ b/lib/attr_masker/performer.rb
@@ -37,6 +37,8 @@ module AttrMasker
         klass = instance.class
 
         updates = klass.masker_attributes.values.reduce({}) do |acc, attribute|
+          next acc unless attribute.should_mask?(instance)
+
           attr_name = attribute.name
           column_name = attribute.column_name
           masker_value = instance.mask(attr_name)

--- a/spec/attribute_spec.rb
+++ b/spec/attribute_spec.rb
@@ -1,0 +1,18 @@
+# (c) 2017 Ribose Inc.
+#
+
+require "spec_helper"
+
+RSpec.describe AttrMasker::Attribute do
+  describe "::new" do
+    subject { described_class.method :new }
+
+    it "instantiates a new attribute definition" do
+      opts = { arbitrary: :options }
+      retval = subject.call(:some_attr, :some_model, opts)
+      expect(retval.name).to eq(:some_attr)
+      expect(retval.model).to eq(:some_model)
+      expect(retval.options).to eq(opts)
+    end
+  end
+end

--- a/spec/attribute_spec.rb
+++ b/spec/attribute_spec.rb
@@ -31,6 +31,30 @@ RSpec.describe AttrMasker::Attribute do
     end
   end
 
+  describe "#should_mask?" do
+    subject { described_class.instance_method :should_mask? }
+
+    let(:model_instance) { double }
+    let(:truthy) { double call: true }
+    let(:falsey) { double call: false }
+
+    example { expect(retval_for_opts({})).to be(true) }
+    example { expect(retval_for_opts(if: truthy)).to be(true) }
+    example { expect(retval_for_opts(if: falsey)).to be(false) }
+    example { expect(retval_for_opts(unless: truthy)).to be(false) }
+    example { expect(retval_for_opts(unless: falsey)).to be(true) }
+    example { expect(retval_for_opts(if: truthy, unless: truthy)).to be(false) }
+    example { expect(retval_for_opts(if: truthy, unless: falsey)).to be(true) }
+    example { expect(retval_for_opts(if: falsey, unless: truthy)).to be(false) }
+    example { expect(retval_for_opts(if: falsey, unless: falsey)).to be(false) }
+
+    def retval_for_opts(opts)
+      receiver = described_class.new(:some_attr, :some_model, opts)
+      callable = subject.bind(receiver)
+      callable.(model_instance)
+    end
+  end
+
   describe "#evaluate_option" do
     subject { receiver.method :evaluate_option }
     let(:receiver) { described_class.new :some_attr, model_instance, options }

--- a/spec/attribute_spec.rb
+++ b/spec/attribute_spec.rb
@@ -63,4 +63,42 @@ RSpec.describe AttrMasker::Attribute do
       end
     end
   end
+
+  describe "#marshal_data" do
+    subject { receiver.method :marshal_data }
+    let(:receiver) { described_class.new :some_attr, model_instance, options }
+    let(:options) { { marshaler: marshaller, dump_method: :dump_m } }
+    let(:marshaller) { double }
+    let(:model_instance) { double }
+
+    it "returns unmodified argument when marshal option is falsey" do
+      options[:marshal] = false
+      expect(subject.call(:data)).to be(:data)
+    end
+
+    it "returns unmodified argument when marshal option is falsey" do
+      options[:marshal] = true
+      expect(marshaller).to receive(:dump_m).with(:data).and_return(:retval)
+      expect(subject.call(:data)).to be(:retval)
+    end
+  end
+
+  describe "#unmarshal_data" do
+    subject { receiver.method :unmarshal_data }
+    let(:receiver) { described_class.new :some_attr, model_instance, options }
+    let(:options) { { marshaler: marshaller, load_method: :load_m } }
+    let(:marshaller) { double }
+    let(:model_instance) { double }
+
+    it "returns unmodified argument when marshal option is falsey" do
+      options[:marshal] = false
+      expect(subject.call(:data)).to be(:data)
+    end
+
+    it "returns unmodified argument when marshal option is falsey" do
+      options[:marshal] = true
+      expect(marshaller).to receive(:load_m).with(:data).and_return(:retval)
+      expect(subject.call(:data)).to be(:retval)
+    end
+  end
 end

--- a/spec/attribute_spec.rb
+++ b/spec/attribute_spec.rb
@@ -30,4 +30,37 @@ RSpec.describe AttrMasker::Attribute do
       expect(subject.call).to eq(:some_column)
     end
   end
+
+  describe "#evaluate_option" do
+    subject { receiver.method :evaluate_option }
+    let(:receiver) { described_class.new :some_attr, model_instance, options }
+    let(:options) { {} }
+    let(:model_instance) { double }
+    let(:retval) { subject.call(:option_name, model_instance) }
+
+    context "when that option value is a symbol" do
+      let(:options) { { option_name: :meth } }
+
+      before do
+        allow(model_instance).to receive(:meth).with(no_args).and_return(:rv)
+      end
+
+      it "evaluates an object's method pointed by that symbol" do
+        expect(retval).to be(:rv)
+      end
+    end
+
+    context "when that option_nameion value responds to #call" do
+      let(:options) { { option_name: callable } }
+      let(:callable) { double }
+
+      before do
+        allow(callable).to receive(:call).with(model_instance).and_return(:rv)
+      end
+
+      it "calls #call on it passing model instance as the only argument" do
+        expect(retval).to be(:rv)
+      end
+    end
+  end
 end

--- a/spec/attribute_spec.rb
+++ b/spec/attribute_spec.rb
@@ -15,4 +15,19 @@ RSpec.describe AttrMasker::Attribute do
       expect(retval.options).to eq(opts)
     end
   end
+
+  describe "#column_name" do
+    subject { receiver.method :column_name }
+    let(:receiver) { described_class.new :some_attr, :some_model, options }
+    let(:options) { {} }
+
+    it "defaults to attribute name" do
+      expect(subject.call).to eq(:some_attr)
+    end
+
+    it "can be overriden with :column_name option" do
+      options[:column_name] = :some_column
+      expect(subject.call).to eq(:some_column)
+    end
+  end
 end


### PR DESCRIPTION
Major refactoring. Introduce an `Attribute` class which stores everything related to given masker attribute, and provides logic for masking it on given objects.