### PR TITLE
Mask records disregarding default_scope

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -69,6 +69,11 @@ attr_masker :email :unless => ->(record) { ! record.tester_user? }
 attr_masker :first_name, :if => :tester_user?
 ----
 
+The ActiveRecord's `::default_scope` method has no effect on masking.  All
+table records are updated, provided that :if and :unless filters allow that.
+For example, if you're using a Paranoia[https://github.com/rubysherpas/paranoia]
+gem to soft-delete your data, records marked as deleted will be masked as well.
+
 === Using custom maskers
 
 By default, data is maksed with `AttrMasker::Maskers::SIMPLE` masker which

--- a/lib/attr_masker/performer.rb
+++ b/lib/attr_masker/performer.rb
@@ -24,7 +24,7 @@ module AttrMasker
 
       def mask_class(klass)
         progressbar_for_model(klass) do |bar|
-          klass.all.each do |model|
+          klass.all.unscoped.each do |model|
             mask_object model
             bar.increment
           end
@@ -44,13 +44,13 @@ module AttrMasker
           acc.merge!(column_name => masker_value)
         end
 
-        klass.all.update(instance.id, updates)
+        klass.all.unscoped.update(instance.id, updates)
       end
 
       def progressbar_for_model(klass)
         bar = ProgressBar.create(
           title: klass.name,
-          total: klass.count,
+          total: klass.unscoped.count,
           throttle_rate: 0.1,
           format: %q[%t %c/%C (%j%%) %B %E],
         )

--- a/spec/features_spec.rb
+++ b/spec/features_spec.rb
@@ -269,6 +269,22 @@ RSpec.describe "Attr Masker gem", :suppress_progressbar do
     end
   end
 
+  example "It masks records disregarding default scope" do
+    User.class_eval do
+      attr_masker :last_name
+
+      default_scope ->() { where(last_name: "Solo") }
+    end
+
+    expect { run_rake_task }.not_to(change { User.unscoped.count })
+
+    [han, luke].each do |record|
+      expect { record.reload }.to(
+        change { record.last_name }.to("(redacted)")
+      )
+    end
+  end
+
   def run_rake_task
     Rake::Task["db:mask"].execute
   end


### PR DESCRIPTION
Mask all the records, no matter if `default_scope` is defined for given model or not.