### PR TITLE
Turn the simple masker into a class

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -76,7 +76,7 @@ gem to soft-delete your data, records marked as deleted will be masked as well.
 
 === Using custom maskers
 
-By default, data is maksed with `AttrMasker::Maskers::SIMPLE` masker which
+By default, data is maksed with `AttrMasker::Maskers::Simple` masker which
 always returns `"(redacted)"` string.  But anything what responds to `#call`
 can be used instead: a lambda, `Method` instance, and more.  You can specify it
 by setting the `:masker` option.
@@ -100,7 +100,7 @@ customize masker's behaviour.
 
 Attr Masker comes with several built-in maskers.
 
-`AttrMasker::Maskers::SIMPLE`::
+`AttrMasker::Maskers::Simple`::
 +
 Simply replaces any value with the `"(redacted)"`.  Only useful for columns
 containing textual data.
@@ -112,7 +112,7 @@ Example:
 [source,ruby]
 ----
 attr_masker :first_name
-attr_masker :last_name, :masker => AttrMasker::Maskers::SIMPLE
+attr_masker :last_name, :masker => AttrMasker::Maskers::Simple.new
 ----
 +
 Would set both `first_name` and `last_name` attributes to `"(redacted)"`.

--- a/lib/attr_masker.rb
+++ b/lib/attr_masker.rb
@@ -12,7 +12,7 @@ module AttrMasker
 
   module Maskers
     autoload :Replacing, "attr_masker/maskers/replacing"
-    autoload :SIMPLE, "attr_masker/maskers/simple"
+    autoload :Simple, "attr_masker/maskers/simple"
   end
 
   require "attr_masker/railtie" if defined?(Rails)

--- a/lib/attr_masker/maskers/simple.rb
+++ b/lib/attr_masker/maskers/simple.rb
@@ -5,8 +5,10 @@ module AttrMasker
     # +opts+ is a Hash with the key :value that gives you the current attribute
     # value.
     #
-    SIMPLE = lambda do |_opts|
-      "(redacted)"
+    class Simple
+      def call(_opts)
+        "(redacted)"
+      end
     end
   end
 end

--- a/lib/attr_masker/model.rb
+++ b/lib/attr_masker/model.rb
@@ -82,7 +82,7 @@ module AttrMasker
         marshaler: Marshal,
         dump_method: "dump",
         load_method: "load",
-        masker: AttrMasker::Maskers::SIMPLE,
+        masker: AttrMasker::Maskers::Simple.new,
       }
 
       options = args.extract_options!.

--- a/spec/unit/maskers/simple_spec.rb
+++ b/spec/unit/maskers/simple_spec.rb
@@ -5,8 +5,8 @@
 
 require "spec_helper"
 
-RSpec.describe AttrMasker::Maskers::SIMPLE do
-  subject { described_class }
+RSpec.describe AttrMasker::Maskers::Simple do
+  subject { described_class.new }
 
   example { expect(subject.(value: "Solo")).to eq("(redacted)") }
   example { expect(subject.(value: Math::PI)).to eq("(redacted)") }


### PR DESCRIPTION
Although it could be a constant object as it used to be, there's no actual need for that.  Having all maskers as classes makes things more consistent, cleaner and less surprising.