### PR TITLE
Make sure the support files are imported in sorted order

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@
 require "bundler"
 Bundler.require :default, :development
 
-Dir[File.expand_path "../support/**/*.rb", __FILE__].each { |f| require f }
+Dir[File.expand_path "../support/**/*.rb", __FILE__].sort.each { |f| require f }
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
The order of results for Dir.glob isn't deterministic and the project seems to rely on that order to load the proper configs.