### PR TITLE
Preload all application's models in the Rake task

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -16,6 +16,8 @@ namespace :db do
   # http://stackoverflow.com/questions/14163938/activerecordconnectionnotestablished-within-a-rake-task
   #
   task :mask => :environment do
+    Rails.application.eager_load!
+
     performers = AttrMasker::Performer::Base.descendants.map(&:new)
     performers.select!(&:dependencies_available?)
 

--- a/spec/dummy/app/models/non_persisted_model.rb
+++ b/spec/dummy/app/models/non_persisted_model.rb
@@ -1,0 +1,2 @@
+class NonPersistedModel
+end

--- a/spec/unit/rake_task_spec.rb
+++ b/spec/unit/rake_task_spec.rb
@@ -1,0 +1,14 @@
+# (c) 2017 Ribose Inc.
+#
+
+require "spec_helper"
+
+RSpec.describe "db:mask", :suppress_progressbar do
+  subject { Rake::Task["db:mask"] }
+
+  it "loads all application's models eagerly" do
+    expect(Rails.application).to receive(:eager_load!)
+    subject.execute
+    expect(defined? NonPersistedModel).to be_truthy
+  end
+end


### PR DESCRIPTION
Load the Rails application eagerly, therefore make maskable models defined. Fixes #46.