### PR TITLE
Use attribute writers when assigning masked values

### DIFF
--- a/lib/attr_masker/attribute.rb
+++ b/lib/attr_masker/attribute.rb
@@ -35,7 +35,7 @@ module AttrMasker
     def mask(model_instance)
       value = unmarshal_data(model_instance.send(name))
       masker_value = options[:masker].call(options.merge!(value: value))
-      marshal_data(masker_value)
+      model_instance.send("#{name}=", marshal_data(masker_value))
     end
 
     # Evaluates option (typically +:if+ or +:unless+) on given model instance.

--- a/lib/attr_masker/performer.rb
+++ b/lib/attr_masker/performer.rb
@@ -68,7 +68,7 @@ module AttrMasker
       end
 
       def make_update(instance, updates)
-        instance.class.all.unscoped.update(instance.id, updates)
+        instance.class.all.unscoped.where(id: instance.id).update_all(updates)
       end
     end
 

--- a/lib/attr_masker/performer.rb
+++ b/lib/attr_masker/performer.rb
@@ -36,8 +36,9 @@ module AttrMasker
           next acc unless attribute.should_mask?(instance)
 
           column_name = attribute.column_name
-          masker_value = attribute.mask(instance)
-          acc.merge!(column_name => masker_value)
+          attribute.mask(instance)
+          update = instance.changes[column_name]
+          update.present? ? acc.merge!(column_name => update[1]) : acc
         end
 
         make_update instance, updates unless updates.empty?

--- a/lib/attr_masker/performer.rb
+++ b/lib/attr_masker/performer.rb
@@ -1,5 +1,8 @@
 # (c) 2017 Ribose Inc.
 #
+
+# rubocop:disable Rails/SkipsModelValidations
+
 module AttrMasker
   module Performer
     class Base


### PR DESCRIPTION
Use attribute writers when assigning masked values. As discussed in #22, it's very useful in some cases.