### PR TITLE
Supersede column_name option with column_names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,6 @@ matrix:
       gemfile: "gemfiles/Rails-5.0.gemfile"
     - rvm: "2.3"
       gemfile: "gemfiles/Rails-4.2.gemfile"
-    - rvm: "2.3"
-      gemfile: "gemfiles/Rails-4.1.gemfile"
-    - rvm: "2.2"
-      gemfile: "gemfiles/Rails-4.0.gemfile"
     - rvm: "2.4"
       gemfile: "gemfiles/Rails-5.1.gemfile"
       env:

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,9 @@
 == Not released yet
 
+* Drop support for Rails < 4.2
+* Allow masking attributes which span on more than one column (or field),
+  supersede `column_name` option with `column_names`
+
 == 0.2.1
 
 * Bugfix: preload application to find all models

--- a/README.adoc
+++ b/README.adoc
@@ -13,8 +13,8 @@ Mask ActiveRecord/Mongoid data with ease!
 == Introduction
 
 This gem is intended to mask sensitive data so that production database dumps
-can be used in staging or test environments.  It works with Rails 4+ and modern
-Rubies.  It supports Active Record and Mongoid models.
+can be used in staging or test environments.  It works with Rails 4.2+ and
+modern Rubies.  It supports Active Record and Mongoid models.
 
 == Getting started
 

--- a/gemfiles/Rails-4.0.gemfile
+++ b/gemfiles/Rails-4.0.gemfile
@@ -1,3 +1,0 @@
-eval File.read "gemfiles/common.gemfile"
-
-gem "activerecord", "~> 4.0.0"

--- a/gemfiles/Rails-4.1.gemfile
+++ b/gemfiles/Rails-4.1.gemfile
@@ -1,3 +1,0 @@
-eval File.read "gemfiles/common.gemfile"
-
-gem "activerecord", "~> 4.1.0"

--- a/lib/attr_masker/attribute.rb
+++ b/lib/attr_masker/attribute.rb
@@ -38,6 +38,13 @@ module AttrMasker
       model_instance.send("#{name}=", marshal_data(masker_value))
     end
 
+    # Returns a hash of maskable attribute names, and respective attribute
+    # values.  Unchanged attributes are skipped.
+    def masked_attributes_new_values(model_instance)
+      value = model_instance.changes[column_name]
+      value.present? ? { column_name => value[1] } : {}
+    end
+
     # Evaluates option (typically +:if+ or +:unless+) on given model instance.
     # That option can be either a proc (a model is passed as an only argument),
     # or a symbol (a method of that name is called on model instance).

--- a/lib/attr_masker/attribute.rb
+++ b/lib/attr_masker/attribute.rb
@@ -41,7 +41,7 @@ module AttrMasker
     # Returns a hash of maskable attribute names, and respective attribute
     # values.  Unchanged attributes are skipped.
     def masked_attributes_new_values(model_instance)
-      model_instance.changes.slice(column_name).transform_values(&:second)
+      model_instance.changes.slice(*column_names).transform_values(&:second)
     end
 
     # Evaluates option (typically +:if+ or +:unless+) on given model instance.

--- a/lib/attr_masker/attribute.rb
+++ b/lib/attr_masker/attribute.rb
@@ -69,8 +69,8 @@ module AttrMasker
       options[:marshaler].send(options[:load_method], data)
     end
 
-    def column_name
-      options[:column_name] || name
+    def column_names
+      options[:column_names] || [name]
     end
   end
 end

--- a/lib/attr_masker/attribute.rb
+++ b/lib/attr_masker/attribute.rb
@@ -41,8 +41,7 @@ module AttrMasker
     # Returns a hash of maskable attribute names, and respective attribute
     # values.  Unchanged attributes are skipped.
     def masked_attributes_new_values(model_instance)
-      value = model_instance.changes[column_name]
-      value.present? ? { column_name => value[1] } : {}
+      model_instance.changes.slice(column_name).transform_values(&:second)
     end
 
     # Evaluates option (typically +:if+ or +:unless+) on given model instance.

--- a/lib/attr_masker/performer.rb
+++ b/lib/attr_masker/performer.rb
@@ -38,10 +38,8 @@ module AttrMasker
         updates = klass.masker_attributes.values.reduce({}) do |acc, attribute|
           next acc unless attribute.should_mask?(instance)
 
-          column_name = attribute.column_name
           attribute.mask(instance)
-          update = instance.changes[column_name]
-          update.present? ? acc.merge!(column_name => update[1]) : acc
+          acc.merge! attribute.masked_attributes_new_values(instance)
         end
 
         make_update instance, updates unless updates.empty?

--- a/spec/unit/attribute_spec.rb
+++ b/spec/unit/attribute_spec.rb
@@ -78,8 +78,15 @@ RSpec.describe AttrMasker::Attribute do
 
     it "allows overriding column/field name to be updated with column_name \
       option" do
-      options[:column_name] = :other_attr
+      options[:column_names] = %i[other_attr]
       expect(subject.(model_instance)).to eq({ other_attr: "other" })
+    end
+
+    it "allows specifying more than one column/field name to be updated \
+      with column_name option" do
+      options[:column_names] = %i[some_attr other_attr]
+      expect(subject.(model_instance)).
+        to eq({ some_attr: "new", other_attr: "other" })
     end
     # rubocop:enable Style/BracesAroundHashParameters
   end

--- a/spec/unit/attribute_spec.rb
+++ b/spec/unit/attribute_spec.rb
@@ -16,17 +16,17 @@ RSpec.describe AttrMasker::Attribute do
     end
   end
 
-  describe "#column_name" do
-    subject { receiver.method :column_name }
+  describe "#column_names" do
+    subject { receiver.method :column_names }
     let(:receiver) { described_class.new :some_attr, :some_model, options }
     let(:options) { {} }
 
-    it "defaults to attribute name" do
-      expect(subject.call).to eq(:some_attr)
+    it "defaults to array containing attribute name only" do
+      expect(subject.call).to contain_exactly(:some_attr)
     end
 
-    it "can be overriden with :column_name option" do
-      options[:column_name] = :some_column
+    it "can be overriden with :column_names option" do
+      options[:column_names] = :some_column
       expect(subject.call).to eq(:some_column)
     end
   end

--- a/spec/unit/attribute_spec.rb
+++ b/spec/unit/attribute_spec.rb
@@ -55,6 +55,35 @@ RSpec.describe AttrMasker::Attribute do
     end
   end
 
+  describe "#masked_attributes_new_values" do
+    subject { receiver.method :masked_attributes_new_values }
+    let(:receiver) { described_class.new :some_attr, :some_model, options }
+    let(:options) { {} }
+    let(:model_instance) { double } # Struct.new(:some_attr, :other_attr) }
+    let(:changes) { { some_attr: [nil, "new"], other_attr: [nil, "other"] } }
+
+    before { allow(model_instance).to receive(:changes).and_return(changes) }
+
+    # rubocop:disable Style/BracesAroundHashParameters
+    # We are comparing hashes here, and we want hash literals
+    it "returns a hash of required database updates which include masked field \
+        change, but ignores other attribute changes" do
+      expect(subject.(model_instance)).to eq({ some_attr: "new" })
+    end
+
+    it "returns an emtpy hash for an unchanged object" do
+      changes.clear
+      expect(subject.(model_instance)).to eq({})
+    end
+
+    it "allows overriding column/field name to be updated with column_name \
+      option" do
+      options[:column_name] = :other_attr
+      expect(subject.(model_instance)).to eq({ other_attr: "other" })
+    end
+    # rubocop:enable Style/BracesAroundHashParameters
+  end
+
   describe "#evaluate_option" do
     subject { receiver.method :evaluate_option }
     let(:receiver) { described_class.new :some_attr, model_instance, options }


### PR DESCRIPTION
Support masking attributes which persistence layer spans on more than one table column or, document field.