### PR TITLE
Pass 'model_instance' as 'model:' into custom masker's Proc

### DIFF
--- a/lib/attr_masker/attribute.rb
+++ b/lib/attr_masker/attribute.rb
@@ -34,7 +34,7 @@ module AttrMasker
     # returning.
     def mask(model_instance)
       value = unmarshal_data(model_instance.send(name))
-      masker_value = options[:masker].call(options.merge!(value: value))
+      masker_value = options[:masker].call(options.merge!(value: value, model: model_instance))
       model_instance.send("#{name}=", marshal_data(masker_value))
     end
 

--- a/spec/features/shared_examples.rb
+++ b/spec/features/shared_examples.rb
@@ -176,6 +176,35 @@ RSpec.shared_examples "Attr Masker gem feature specs" do
     )
   end
 
+  example "Using a custom masker with model" do
+    first_name_masker = ->(value:, model:, **_) do
+      value.reverse + model.email
+    end
+
+    last_name_masker = ->(value:, model:, **_) do
+      model.email + value.upcase
+    end
+
+    User.class_eval do
+      attr_masker :first_name, masker: first_name_masker
+      attr_masker :last_name, masker: last_name_masker
+    end
+
+    expect { run_rake_task }.not_to(change { User.count })
+
+    expect { han.reload }.to(
+      change { han.first_name }.to("naHhan@example.test") &
+      change { han.last_name }.to("han@example.testSOLO") &
+      preserve { han.email }
+    )
+
+    expect { luke.reload }.to(
+      change { luke.first_name }.to("ekuLluke@jedi.example.test") &
+      change { luke.last_name }.to("luke@jedi.example.testSKYWALKER") &
+      preserve { luke.email }
+    )
+  end
+
   example "Masked value is assigned via attribute writer" do
     User.class_eval do
       attr_masker :first_name, :last_name


### PR DESCRIPTION
This allows for something like this:

```ruby
attr_masker :stuff, masker: ->(model:) { model.species =~ /cat/ ? 'miao' : 'woof' }
```

Ref #5 