### PR TITLE
Upgrade Rubocop, and embedded Thoughtbot's guide

### DIFF
--- a/.rubocop.tb.yml
+++ b/.rubocop.tb.yml
@@ -352,8 +352,18 @@ Style/TrailingCommaInArguments:
     - no_comma
   Enabled: true
 
-Style/TrailingCommaInLiteral:
-  Description: 'Checks for trailing comma in array and hash literals.'
+Style/TrailingCommaInArrayLiteral:
+  Description: 'Checks for trailing comma in array literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  EnforcedStyleForMultiline: comma
+  SupportedStylesForMultiline:
+    - comma
+    - consistent_comma
+    - no_comma
+  Enabled: true
+
+Style/TrailingCommaInHashLiteral:
+  Description: 'Checks for trailing comma in hash literals.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
   EnforcedStyleForMultiline: comma
   SupportedStylesForMultiline:
@@ -396,6 +406,13 @@ Style/WordArray:
 Layout/AlignParameters:
   Description: 'Here we check if the parameters on a multi-line method call or definition are aligned.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-double-indent'
+  Enabled: false
+
+Layout/ConditionPosition:
+  Description: >-
+                 Checks for condition placed in a confusing position relative to
+                 the keyword.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#same-line-condition'
   Enabled: false
 
 Layout/DotPosition:
@@ -448,13 +465,6 @@ Lint/AssignmentInCondition:
 
 Lint/CircularArgumentReference:
   Description: "Don't refer to the keyword argument in the default value."
-  Enabled: false
-
-Lint/ConditionPosition:
-  Description: >-
-                 Checks for condition placed in a confusing position relative to
-                 the keyword.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#same-line-condition'
   Enabled: false
 
 Lint/DeprecatedClassMethods:
@@ -523,7 +533,7 @@ Lint/UnderscorePrefixedVariableName:
   Description: 'Do not use prefix `_` for a variable that is used.'
   Enabled: false
 
-Lint/UnneededDisable:
+Lint/UnneededCopDisableDirective:
   Description: >-
                  Checks for rubocop:disable comments that can be removed.
                  Note: this cop is not disabled when disabling all cops.

--- a/attr_masker.gemspec
+++ b/attr_masker.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("mongoid", ">= 5")
   gem.add_development_dependency("pry")
   gem.add_development_dependency("rspec", ">= 3.0")
-  gem.add_development_dependency("rubocop", "~> 0.51.0")
+  gem.add_development_dependency("rubocop", "~> 0.54.0")
   gem.add_development_dependency("simplecov")
   gem.add_development_dependency("sqlite3", "~> 1.3.13")
 end


### PR DESCRIPTION
Upgarde Thoughtbot's style guide for Rubocop 0.53-0.54, see:

- riboseinc/oss-guides#11
- thoughtbot/guides#510

Update Rubocop to 0.54 as well.