### PR TITLE
Prepare for Bundler 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,10 @@ services:
   - mongodb
 
 before_install:
-  - gem install bundler -v 1.15.1
+  - gem install bundler -v 1.17.3
+
+install:
+  - bundle _1.17.3_ install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
 
 script:
   - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 sudo: false
 dist: trusty
 language: ruby
-before_install: gem install bundler -v 1.15.1
 
 services:
   - mongodb
+
+before_install:
+  - gem install bundler -v 1.15.1
 
 script:
   - bundle exec rspec

--- a/attr_masker.gemspec
+++ b/attr_masker.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("rails", ">= 4.0.0", "< 6.0")
   gem.add_runtime_dependency("ruby-progressbar", "~> 1.8")
 
-  gem.add_development_dependency("bundler", "~> 1.15")
+  gem.add_development_dependency("bundler", ">= 1.15")
   gem.add_development_dependency("combustion", "~> 1.0")
   gem.add_development_dependency("database_cleaner", "~> 1.6")
   # Older versions aren't needed as we don't support Rails < 4


### PR DESCRIPTION
Relax Bundler development dependency, so that 2.x is allowed.  However, use the latest 1.x in Travis CI for compatibility with Rails 4.