### PR TITLE
Use #eval_gemfile in gemfiles

### DIFF
--- a/gemfiles/Rails-4.2.gemfile
+++ b/gemfiles/Rails-4.2.gemfile
@@ -1,4 +1,3 @@
-# rubocop:disable Security/Eval
-eval File.read "gemfiles/common.gemfile"
+eval_gemfile "common.gemfile"
 
 gem "activerecord", "~> 4.2.0"

--- a/gemfiles/Rails-5.0.gemfile
+++ b/gemfiles/Rails-5.0.gemfile
@@ -1,4 +1,3 @@
-# rubocop:disable Security/Eval
-eval File.read "gemfiles/common.gemfile"
+eval_gemfile "common.gemfile"
 
 gem "activerecord", "~> 5.0.0"

--- a/gemfiles/Rails-5.1.gemfile
+++ b/gemfiles/Rails-5.1.gemfile
@@ -1,4 +1,3 @@
-# rubocop:disable Security/Eval
-eval File.read "gemfiles/common.gemfile"
+eval_gemfile "common.gemfile"
 
 gem "activerecord", "~> 5.1.0"

--- a/gemfiles/Rails-5.2.gemfile
+++ b/gemfiles/Rails-5.2.gemfile
@@ -1,4 +1,3 @@
-# rubocop:disable Security/Eval
-eval File.read "gemfiles/common.gemfile"
+eval_gemfile "common.gemfile"
 
 gem "activerecord", "~> 5.2.0"

--- a/gemfiles/Rails-head.gemfile
+++ b/gemfiles/Rails-head.gemfile
@@ -1,5 +1,4 @@
-# rubocop:disable Security/Eval
-eval File.read "gemfiles/common.gemfile"
+eval_gemfile "common.gemfile"
 
 gem "activerecord", github: "rails/rails"
 gem "arel", github: "rails/arel"


### PR DESCRIPTION
Replace evil `Kernel#eval` with `#eval_gemfile` from Bundler's DSL.