### PR TITLE
Add support for Rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,19 +22,20 @@ rvm:
   - "ruby-head"
 
 gemfile:
-  - gemfiles/Rails-5.2.gemfile
+  - gemfiles/Rails-6.0.gemfile
 
 matrix:
   include:
     - gemfile: "gemfiles/Rails-head.gemfile"
+    - gemfile: "gemfiles/Rails-5.2.gemfile"
     - gemfile: "gemfiles/Rails-5.1.gemfile"
     - gemfile: "gemfiles/Rails-5.0.gemfile"
     - gemfile: "gemfiles/Rails-4.2.gemfile"
       rvm: "2.3"
-    - gemfile: "gemfiles/Rails-5.2.gemfile"
+    - gemfile: "gemfiles/Rails-6.0.gemfile"
       env:
         - WITHOUT_ACTIVE_RECORD: "1"
-    - gemfile: "gemfiles/Rails-5.2.gemfile"
+    - gemfile: "gemfiles/Rails-6.0.gemfile"
       env:
         - WITHOUT_MONGOID: "1"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,29 +15,32 @@ script:
 
 rvm:
   - "2.7"
-  - "2.6"
-  - "2.5"
-  - "2.4"
-  - "2.3"
-  - "ruby-head"
 
 gemfile:
   - gemfiles/Rails-6.0.gemfile
 
 matrix:
   include:
+    - env:
+        - WITHOUT_ACTIVE_RECORD: "1"
+    - env:
+        - WITHOUT_MONGOID: "1"
     - gemfile: "gemfiles/Rails-head.gemfile"
     - gemfile: "gemfiles/Rails-5.2.gemfile"
     - gemfile: "gemfiles/Rails-5.1.gemfile"
     - gemfile: "gemfiles/Rails-5.0.gemfile"
     - gemfile: "gemfiles/Rails-4.2.gemfile"
+      # Rails 4.2 doesn't work with newer Rubies.
       rvm: "2.3"
-    - gemfile: "gemfiles/Rails-6.0.gemfile"
-      env:
-        - WITHOUT_ACTIVE_RECORD: "1"
-    - gemfile: "gemfiles/Rails-6.0.gemfile"
-      env:
-        - WITHOUT_MONGOID: "1"
+    - rvm: ruby-head
+    - rvm: 2.6
+    - rvm: 2.5
+    - rvm: 2.4
+      # The latest Rails supported on this Ruby
+      gemfile: "gemfiles/Rails-5.2.gemfile"
+    - rvm: 2.3
+      # The latest Rails supported on this Ruby
+      gemfile: "gemfiles/Rails-5.2.gemfile"
 
   allow_failures:
     - rvm: "ruby-head"

--- a/attr_masker.gemspec
+++ b/attr_masker.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("rspec", ">= 3.0")
   gem.add_development_dependency("rubocop", "~> 0.54.0")
   gem.add_development_dependency("simplecov")
-  gem.add_development_dependency("sqlite3", "~> 1.3.13")
+  gem.add_development_dependency("sqlite3", ">= 1.3.13", "< 2")
 end

--- a/attr_masker.gemspec
+++ b/attr_masker.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency("rails", ">= 4.0.0", "< 6.0")
+  gem.add_runtime_dependency("rails", ">= 4.0.0", "< 7")
   gem.add_runtime_dependency("ruby-progressbar", "~> 1.8")
 
   gem.add_development_dependency("bundler", ">= 1.15")

--- a/gemfiles/Rails-4.2.gemfile
+++ b/gemfiles/Rails-4.2.gemfile
@@ -1,3 +1,4 @@
 eval_gemfile "common.gemfile"
 
 gem "activerecord", "~> 4.2.0"
+gem "sqlite3", "~> 1.3.13"

--- a/gemfiles/Rails-5.0.gemfile
+++ b/gemfiles/Rails-5.0.gemfile
@@ -1,3 +1,4 @@
 eval_gemfile "common.gemfile"
 
 gem "activerecord", "~> 5.0.0"
+gem "sqlite3", "~> 1.3.13"

--- a/gemfiles/Rails-5.1.gemfile
+++ b/gemfiles/Rails-5.1.gemfile
@@ -1,3 +1,4 @@
 eval_gemfile "common.gemfile"
 
 gem "activerecord", "~> 5.1.0"
+gem "sqlite3", "~> 1.3.13"

--- a/gemfiles/Rails-5.2.gemfile
+++ b/gemfiles/Rails-5.2.gemfile
@@ -1,3 +1,4 @@
 eval_gemfile "common.gemfile"
 
 gem "activerecord", "~> 5.2.0"
+gem "sqlite3", "~> 1.3.13"

--- a/gemfiles/Rails-6.0.gemfile
+++ b/gemfiles/Rails-6.0.gemfile
@@ -1,0 +1,3 @@
+eval_gemfile "common.gemfile"
+
+gem "activerecord", "~> 6.0.0"


### PR DESCRIPTION
- Relax dependency constraints
- Update test suite for changes in `ActiveSupport::DescendantsTracker` in Rails 6
- Test against Rails 6 in Travis CI
