### PR TITLE
Fix code style violations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,9 @@ AllCops:
 
 Rails:
   Enabled: true
+
+# Hashrocket style looks better when describing task dependencies.
+Style/HashSyntax:
+  Exclude:
+    - Rakefile
+    - "**/*.rake"

--- a/attr_masker.gemspec
+++ b/attr_masker.gemspec
@@ -1,7 +1,7 @@
 # (c) 2017 Ribose Inc.
 #
 
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "attr_masker/version"
 

--- a/lib/attr_masker/attribute.rb
+++ b/lib/attr_masker/attribute.rb
@@ -34,7 +34,9 @@ module AttrMasker
     # returning.
     def mask(model_instance)
       value = unmarshal_data(model_instance.send(name))
-      masker_value = options[:masker].call(options.merge!(value: value, model: model_instance))
+      masker = options[:masker]
+      masker_options = options.merge!(value: value, model: model_instance)
+      masker_value = masker.call(masker_options)
       model_instance.send("#{name}=", marshal_data(masker_value))
     end
 

--- a/lib/attr_masker/attribute.rb
+++ b/lib/attr_masker/attribute.rb
@@ -61,11 +61,13 @@ module AttrMasker
 
     def marshal_data(data)
       return data unless options[:marshal]
+
       options[:marshaler].send(options[:dump_method], data)
     end
 
     def unmarshal_data(data)
       return data unless options[:marshal]
+
       options[:marshaler].send(options[:load_method], data)
     end
 

--- a/lib/attr_masker/model.rb
+++ b/lib/attr_masker/model.rb
@@ -73,6 +73,8 @@ module AttrMasker
     #   @user.masker_configuration # returns the masker version of configuration
     #
     #   See README for more examples
+    #--
+    # rubocop:disable Metrics/MethodLength
     def attr_masker(*args)
       default_options = {
         if: true,
@@ -94,6 +96,7 @@ module AttrMasker
         masker_attributes[attribute.name] = attribute
       end
     end
+    # rubocop:enable Metrics/MethodLength
 
     # Default options to use with calls to <tt>attr_masker</tt>
     # XXX:Keep

--- a/lib/attr_masker/performer.rb
+++ b/lib/attr_masker/performer.rb
@@ -24,6 +24,8 @@ module AttrMasker
       private
 
       # Mask all objects of a class in batches to not run out of memory!
+      #--
+      # rubocop:todo Metrics/MethodLength
       def mask_class(klass)
         progressbar_for_model(klass) do |bar|
           if klass.all.unscoped.respond_to?(:find_each)
@@ -39,6 +41,7 @@ module AttrMasker
           end
         end
       end
+      # rubocop:enable Metrics/MethodLength
 
       # For each masker attribute, mask it, and save it!
       #

--- a/lib/attr_masker/performer.rb
+++ b/lib/attr_masker/performer.rb
@@ -1,8 +1,6 @@
 # (c) 2017 Ribose Inc.
 #
 
-# rubocop:disable Rails/SkipsModelValidations
-
 module AttrMasker
   module Performer
     class Base
@@ -79,9 +77,12 @@ module AttrMasker
         ::ActiveRecord::Base.descendants.select(&:table_exists?)
       end
 
+      #--
+      # rubocop:disable Rails/SkipsModelValidations
       def make_update(instance, updates)
         instance.class.all.unscoped.where(id: instance.id).update_all(updates)
       end
+      # rubocop:enable Rails/SkipsModelValidations
     end
 
     class Mongoid < Base

--- a/lib/attr_masker/performer.rb
+++ b/lib/attr_masker/performer.rb
@@ -9,7 +9,8 @@ module AttrMasker
         #
         if Rails.env.production?
           unless ENV["FORCE_MASK"]
-            raise AttrMasker::Error, "Attempted to run in production environment."
+            msg = "Attempted to run in production environment."
+            raise AttrMasker::Error, msg
           end
         end
 

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,9 +1,6 @@
 # (c) 2017 Ribose Inc.
 #
 
-# Hashrocket style looks better when describing task dependencies.
-# rubocop:disable Style/HashSyntax
-
 namespace :db do
   desc "Mask every DB record according to rules set up in the respective " \
   "ActiveRecord"

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,3 +1,2 @@
 Rails.application.routes.draw do
-  #
 end

--- a/spec/features/active_record_spec.rb
+++ b/spec/features/active_record_spec.rb
@@ -1,9 +1,6 @@
 # (c) 2017 Ribose Inc.
 #
 
-# No point in using ApplicationRecord here.
-# rubocop:disable Rails/ApplicationRecord
-
 require_relative "shared_examples"
 
 RSpec.describe "Attr Masker gem", :suppress_progressbar do
@@ -79,7 +76,12 @@ RSpec.describe "Attr Masker gem", :suppress_progressbar do
       end
     end
 
+    # No point in using ApplicationRecord here.
+    # rubocop:disable Rails/ApplicationRecord
+
     let(:user_class_definition) { Class.new(ActiveRecord::Base) }
+
+    # rubocop:enable Rails/ApplicationRecord
 
     include_examples "Attr Masker gem feature specs"
   end

--- a/spec/features/shared_examples.rb
+++ b/spec/features/shared_examples.rb
@@ -374,3 +374,5 @@ RSpec.shared_examples "Attr Masker gem feature specs" do
     Rake::Task["db:mask"].execute
   end
 end
+
+# rubocop:enable Style/TrailingCommaInArguments

--- a/spec/features/shared_examples.rb
+++ b/spec/features/shared_examples.rb
@@ -358,7 +358,7 @@ RSpec.shared_examples "Attr Masker gem feature specs" do
     User.class_eval do
       attr_masker :last_name
 
-      default_scope ->() { where(last_name: "Solo") }
+      default_scope -> { where(last_name: "Solo") }
     end
 
     expect { run_rake_task }.not_to(change { User.unscoped.count })

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ end
 require "bundler"
 Bundler.require :default, :development
 
-Dir[File.expand_path "../support/**/*.rb", __FILE__].sort.each { |f| require f }
+Dir[File.expand_path "support/**/*.rb", __dir__].sort.each { |f| require f }
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/support/rake.rb
+++ b/spec/support/rake.rb
@@ -3,4 +3,4 @@
 
 require "rake"
 Rails.application.load_tasks
-load File.expand_path("../../../lib/tasks/db.rake", __FILE__)
+load File.expand_path("../../lib/tasks/db.rake", __dir__)


### PR DESCRIPTION
Rubocop is all green now. One questionable offence has been marked with `rubocop:todo`.