### PR TITLE
Add missing build to Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ gemfile:
 
 matrix:
   include:
+    - {}
     - env:
         - WITHOUT: "activerecord"
     - env:


### PR DESCRIPTION
Test against newest Ruby and Rails.

Build matrices which have only one element require that that sole job from the matrix is specified explicitly.

See:
- https://docs.travis-ci.com/user/build-matrix/#explicitly-included-jobs-with-only-one-element-in-the-build-matrix

With a following reservation:
- https://github.com/travis-ci/docs-travis-ci-com/issues/2655