### PR TITLE
Fix #after hooks in feature specs

### DIFF
--- a/spec/features/active_record_spec.rb
+++ b/spec/features/active_record_spec.rb
@@ -51,10 +51,12 @@ RSpec.describe "Attr Masker gem", :suppress_progressbar do
     # this purpose, but fortunately this can be worked around by
     # before(:example) + after(:all) combo.
     after do
-      if ::ActiveSupport.gem_version < Gem::Version.new("6.0.0")
-        ::ActiveSupport::DescendantsTracker.
-          class_variable_get("@@direct_descendants")[::ActiveRecord::Base].
-          delete(user_class_definition)
+      if defined?(::ActiveRecord::Base)
+        if ::ActiveSupport.gem_version < Gem::Version.new("6.0.0")
+          ::ActiveSupport::DescendantsTracker.
+            class_variable_get("@@direct_descendants")[::ActiveRecord::Base].
+            delete(user_class_definition)
+        end
       end
     end
 

--- a/spec/features/mongoid_spec.rb
+++ b/spec/features/mongoid_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Attr Masker gem", :suppress_progressbar do
 
     after do
       # Remove the example-specific model from Mongoid.models
-      ::Mongoid.models.delete(user_class_definition)
+      ::Mongoid.models.delete(user_class_definition) if defined?(::Mongoid)
     end
 
     let(:user_class_definition) do


### PR DESCRIPTION
`after(:example)` hooks are executed regardless given example has succeeded, failed, or was skipped.  Therefore, they were prone to undefined constant errors when run with WITHOUT=X variable set.

This commit fixes the issue by adding guard conditions to these hooks.