### PR TITLE
Constraint Database Cleaner version at < 1.8

### DIFF
--- a/attr_masker.gemspec
+++ b/attr_masker.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("bundler", ">= 1.15")
   gem.add_development_dependency("combustion", "~> 1.0")
-  gem.add_development_dependency("database_cleaner", "~> 1.6")
+  gem.add_development_dependency("database_cleaner", "~> 1.6", "< 1.8")
   # Older versions aren't needed as we don't support Rails < 4
   gem.add_development_dependency("mongoid", ">= 5")
   gem.add_development_dependency("pry")


### PR DESCRIPTION
They just went modular, and we need to prevent the most recent version from being installed until we are ready to migrate. More on that change: https://github.com/riboseinc/attr_masker/issues/83.