### PR TITLE
Organize warnings output with Warning gem

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,23 @@
 # (c) 2017 Ribose Inc.
 #
 
+# Warnings gem must be added to Gemfile or otherwise loaded in order to have
+# the following configuration in effect.
+#
+# TODO: Add Warning to gemspec or Gemfile after dropping support for Ruby 2.3.
+begin
+  require "warning"
+
+  # Deduplicate warnings
+  Warning.dedup
+
+  # Ignore all warnings in Gem dependencies
+  Gem.path.each do |path|
+    Warning.ignore(//, path)
+  end
+rescue LoadError
+end
+
 require "simplecov"
 SimpleCov.start
 


### PR DESCRIPTION
Ignore warnings coming from other gems, and deduplicate remaining ones. Having said that, Warnings gem must be added to Gemfile or somehow manually loaded in order to work.

I am not adding it to gemspec, because it requires Ruby 2.4, and I don't want to drop older Rubies for a rather silly reason.