### PR TITLE
Fix Gemfile for tests without Mongoid

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem "mongoid", require: false


### PR DESCRIPTION
Mongoid gem must not be automatically loaded by Bundler, otherwise running tests with `WITHOUT=mongoid` environment variable will fail.

The same solution is implemented in `gemfiles/common.gemfile`, which is used in CI.