### PR TITLE
Use keyword arguments in all maskers consistently

### DIFF
--- a/lib/attr_masker/attribute.rb
+++ b/lib/attr_masker/attribute.rb
@@ -35,8 +35,7 @@ module AttrMasker
     def mask(model_instance)
       value = unmarshal_data(model_instance.send(name))
       masker = options[:masker]
-      masker_options = options.merge!(value: value, model: model_instance)
-      masker_value = masker.call(masker_options)
+      masker_value = masker.call(value: value, model: model_instance, **options)
       model_instance.send("#{name}=", marshal_data(masker_value))
     end
 

--- a/lib/attr_masker/maskers/simple.rb
+++ b/lib/attr_masker/maskers/simple.rb
@@ -6,7 +6,7 @@ module AttrMasker
     # value.
     #
     class Simple
-      def call(_opts)
+      def call(**_opts)
         "(redacted)"
       end
     end


### PR DESCRIPTION
Implicit conversions between hashes and keyword arguments is deprecated in modern Rubies, and will not work in Ruby 3.0.  Maskers should be parametrized with keyword arguments, not Ruby 1.9-style options hashes, and this very change fixes that.

This change resolves all Ruby 2.7 warnings (see #79), except for those coming from external libraries (e.g. Rails).

See: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/