### PR TITLE
Rework what arguments are passed to maskers

### DIFF
--- a/lib/attr_masker/attribute.rb
+++ b/lib/attr_masker/attribute.rb
@@ -35,7 +35,8 @@ module AttrMasker
     def mask(model_instance)
       value = unmarshal_data(model_instance.send(name))
       masker = options[:masker]
-      masker_value = masker.call(value: value, model: model_instance, **options)
+      masker_value = masker.call(value: value, model: model_instance,
+                                 attribute_name: name, masking_options: options)
       model_instance.send("#{name}=", marshal_data(masker_value))
     end
 

--- a/spec/unit/attribute_spec.rb
+++ b/spec/unit/attribute_spec.rb
@@ -81,6 +81,18 @@ RSpec.describe AttrMasker::Attribute do
       subject.bind(receiver).call(model_instance)
     end
 
+    it "passes the attribute name to the masker" do
+      expect(masker).to receive(:call).
+        with(hash_including(attribute_name: :some_attr))
+      subject.bind(receiver).call(model_instance)
+    end
+
+    it "passes the masking options to the masker" do
+      expect(masker).to receive(:call).
+        with(hash_including(masking_options: options))
+      subject.bind(receiver).call(model_instance)
+    end
+
     it "marshals the masked value, and assigns it to the attribute" do
       expect(receiver).to receive(:marshal_data).
         with("masked_value").and_return("marshalled_masked_value")


### PR DESCRIPTION
- For clarity and predictability, pass all `attr_masker` options to masker in a single hash.
- Pass the attribute name as well.
- Add specs for that, and for `Attribute#mask` method in general.