### PR TITLE
Removed the skelton executables from gem package

### DIFF
--- a/attr_masker.gemspec
+++ b/attr_masker.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |gem|
                           "of certain models by modifying the database."
 
   gem.files         = `git ls-files`.split($/)
-  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 


### PR DESCRIPTION
This gem contained the executables generated by `bundle gem` and the binstubs for rubocop and rspec. It will overwrite the global path of user environment. 

Is it intentional? 