### PR TITLE
Migrate to modular Database Cleaner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,6 @@ source "https://rubygems.org"
 gemspec
 
 gem "mongoid", require: false
+
+gem "database_cleaner-active_record", require: false
+gem "database_cleaner-mongoid", require: false

--- a/attr_masker.gemspec
+++ b/attr_masker.gemspec
@@ -25,7 +25,9 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("bundler", ">= 1.15")
   gem.add_development_dependency("combustion", "~> 1.0")
-  gem.add_development_dependency("database_cleaner", "~> 1.6", "< 1.8")
+  gem.add_development_dependency("database_cleaner", "~> 1.8")
+  gem.add_development_dependency("database_cleaner-active_record", "~> 1.8")
+  gem.add_development_dependency("database_cleaner-mongoid", "~> 1.8")
   # Older versions aren't needed as we don't support Rails < 4
   gem.add_development_dependency("mongoid", ">= 5")
   gem.add_development_dependency("pry")

--- a/gemfiles/common.gemfile
+++ b/gemfiles/common.gemfile
@@ -6,3 +6,6 @@ gem "mongoid", require: false
 
 gem "codecov", require: false
 gem "simplecov", require: false
+
+gem "database_cleaner-active_record", require: false
+gem "database_cleaner-mongoid", require: false

--- a/spec/support/db_cleaner.rb
+++ b/spec/support/db_cleaner.rb
@@ -3,6 +3,7 @@ require "database_cleaner"
 RSpec.configure do |config|
   config.before(:suite) do
     unless WITHOUT_ACTIVE_RECORD
+      require "database_cleaner-active_record"
       DatabaseCleaner[:active_record].strategy = :truncation
     end
 
@@ -10,6 +11,7 @@ RSpec.configure do |config|
     # to list them and to determine collection names to be cleaned.
     # Therefore, they are specified explicitly here.
     unless WITHOUT_MONGOID
+      require "database_cleaner-mongoid"
       DatabaseCleaner[:mongoid].strategy = :truncation, { only: "users" }
     end
 


### PR DESCRIPTION
Since version 1.8, every adapter for Database Cleaner is contained in a separate gem.