### PR TITLE
Deduplicate gemfiles

### DIFF
--- a/gemfiles/common.gemfile
+++ b/gemfiles/common.gemfile
@@ -1,11 +1,4 @@
-source "https://rubygems.org"
-
-gemspec path: ".."
-
-gem "mongoid", require: false
+eval_gemfile "../Gemfile"
 
 gem "codecov", require: false
 gem "simplecov", require: false
-
-gem "database_cleaner-active_record", require: false
-gem "database_cleaner-mongoid", require: false


### PR DESCRIPTION
- Remove code duplications between gemfiles.
- ~Add [Warning](https://rubygems.org/gems/warning/) gem to Gemfile~.