### PR TITLE
Add Warning gem as development dependency

### DIFF
--- a/attr_masker.gemspec
+++ b/attr_masker.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("rubocop", "~> 0.54.0")
   gem.add_development_dependency("simplecov")
   gem.add_development_dependency("sqlite3", ">= 1.3.13", "< 2")
+  gem.add_development_dependency("warning", "~> 1.1")
 end


### PR DESCRIPTION
This gem is already loaded in tests (if available), but was not present in the Gemfile because it requires Ruby 2.4.

This pull request cannot be merged before dropping support for Ruby 2.3.