### PR TITLE
Drop official support for Ruby 2.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,6 @@ jobs:
           - 2.6
           - 2.5
           - 2.4
-          - 2.3
         gemfile:
           - Rails-6.0
           - Rails-5.2
@@ -41,8 +40,6 @@ jobs:
           - gemfile: Rails-4.2
             ruby: 2.7
           # Rails 6.0 requires Ruby 2.5 or above
-          - gemfile: Rails-6.0
-            ruby: 2.3
           - gemfile: Rails-6.0
             ruby: 2.4
 


### PR DESCRIPTION
Stop testing against this old Ruby version.  It is not maintained anymore and problematic, as it was preventing us from adding some development gems to the Gemfile (see #105).