### PR TITLE
Use different Bundler versions in GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,11 @@ jobs:
           - activerecord
           - mongoid
 
+        include:
+          # Rails 4.2 requires Bundler 1.x.
+          - gemfile: Rails-4.2
+            bundler_version: "1.17"
+
         exclude:
           # Rails 4.2 refuses to install on Ruby 2.7 for some reason;
           # anyway, it's a weird combination of old Rails and new Ruby
@@ -68,9 +73,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-
-      - name: Install Bundler
-        run: gem install bundler
+          bundler: ${{ matrix.bundler_version || '2' }}
 
       - name: Install gems
         run: bundle install --jobs 4 --retry 3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,11 +54,6 @@ jobs:
       # https://bundler.io/v1.17/bundle_config.html
       BUNDLE_GEMFILE: ${{ format('gemfiles/{0}.gemfile', matrix.gemfile) }}
 
-      # Rails 4.2 requires Bundler 1.x.
-      # BUNDLE_ALLOW_BUNDLER_DEPENDENCY_CONFLICTS overrides that requirement.
-      # See: https://bundler.io/v2.1/man/bundle-config.1.html
-      BUNDLE_ALLOW_BUNDLER_DEPENDENCY_CONFLICTS: 1
-
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Ruby 2.7 works way better with Bundler 2.x, whereas Rails 4.2 requires Bundler 1.x.  Since this commit, the best-matching Bundler version for each job is used in CI.

This is expected to solve random build failures which were occurring recently, and which were caused by using old Bundler on Ruby 2.7 (#102). This also removes some unclear tricks from CI script.