### PR TITLE
Override Bundler requirements in GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,11 @@ jobs:
       # https://bundler.io/v1.17/bundle_config.html
       BUNDLE_GEMFILE: ${{ format('gemfiles/{0}.gemfile', matrix.gemfile) }}
 
+      # Rails 4.2 requires Bundler 1.x.
+      # BUNDLE_ALLOW_BUNDLER_DEPENDENCY_CONFLICTS overrides that requirement.
+      # See: https://bundler.io/v2.1/man/bundle-config.1.html
+      BUNDLE_ALLOW_BUNDLER_DEPENDENCY_CONFLICTS: 1
+
     steps:
       - uses: actions/checkout@v2
 
@@ -63,12 +68,11 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
 
+      - name: Install Bundler
+        run: gem install bundler
+
       - name: Install gems
-        run: |
-          gem install bundler -v 1.17.3
-          gem uninstall bundler -v '> 1.17.3' || :
-          rm $(gem environment | grep -- '- INSTAL' | sed -e 's/^.*: //')/specifications/default/bundler-2* || :
-          bundle install --jobs 4 --retry 3
+        run: bundle install --jobs 4 --retry 3
 
       - name: Run tests
         run: bundle exec rspec

--- a/gemfiles/Rails-4.2.gemfile
+++ b/gemfiles/Rails-4.2.gemfile
@@ -1,5 +1,4 @@
 eval_gemfile "common.gemfile"
 
 gem "activerecord", "~> 4.2.0"
-gem "bundler", "< 2.0"
 gem "sqlite3", "~> 1.3.13"


### PR DESCRIPTION
Rails 4.2 depends on Bundler 1.x, whereas Ruby 2.7 works way better with Bundler 2.x (running 1.x on Ruby 2.7 may cause random errors).

Arguably the best way to solve this issue is to override dependency on Bundler, allowing version 2.  This is done by setting an environment variable.

This is expected to solve random build failures which were occurring recently (fixes #102).  This also removes some unclear tricks from CI script.