### PR TITLE
Manual trigger for running CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,7 @@ name: Tests
 on:
   - pull_request
   - push
+  - workflow_dispatch
 
 jobs:
   test:


### PR DESCRIPTION
By supporting `workflow_dispatch` event, tests can be launched from GitHub Actions web interface too.