### PR TITLE
Fix constraints on development dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gemspec
 
 gem "mongoid", require: false
 
-gem "database_cleaner-active_record", require: false
-gem "database_cleaner-mongoid", require: false
+gem "database_cleaner-active_record", "~> 1.8", require: false
+gem "database_cleaner-mongoid", "~> 1.8", require: false


### PR DESCRIPTION
These Gemfile entries were resetting dependency version constraints which are specified in gemspec.  The drawback is that now Bundler prints warnings about discouraged practice, but at least it works. A more elegant long-term solution is needed, but for very now, that approach is good enough.
