### PR TITLE
In CI, install gems via setup-ruby action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,9 +69,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler: ${{ matrix.bundler_version || '2' }}
-
-      - name: Install gems
-        run: bundle install --jobs 4 --retry 3
+          bundler-cache: true
 
       - name: Run tests
         run: bundle exec rspec


### PR DESCRIPTION
No need for a separate step.  Also, this way gems will be cached, which should speed things up.