### PR TITLE
Load configuration file if it exists

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -163,6 +163,26 @@ This list is likely to be extended in future versions, and that will not be
 considered a breaking change, therefore it is strongly recommended to always
 use a splat (`**`) at end of argument list of masker's `#call` method.
 
+=== Configuration file
+
+It is also possible to contain all the maskers configuration in one file.
+Just place it in `config/attr_masker.rb`, and it will be loaded from a Rake
+task after the application is fully loaded.  That means you can re-open classes
+and add masker definitions there, for example:
+
+[source,ruby]
+----
+# config/attr_masker.rb
+
+class User
+  attr_masker :first_name, :last_name
+end
+
+class Email
+  attr_masker :address, ->(model:, **) { "mail#{model.id}@example.com" }
+end
+----
+
 == Roadmap & TODOs
 
 - documentation

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -15,6 +15,9 @@ namespace :db do
   task :mask => :environment do
     Rails.application.eager_load!
 
+    config_file = Rails.root.join("config", "attr_masker.rb").to_s
+    require config_file if File.file?(config_file)
+
     performers = AttrMasker::Performer::Base.descendants.map(&:new)
     performers.select!(&:dependencies_available?)
 

--- a/spec/dummy/config/attr_masker.rb
+++ b/spec/dummy/config/attr_masker.rb
@@ -1,0 +1,1 @@
+$CONFIG_LOADED_AT = Time.now

--- a/spec/features/shared_examples.rb
+++ b/spec/features/shared_examples.rb
@@ -370,6 +370,10 @@ RSpec.shared_examples "Attr Masker gem feature specs" do
     end
   end
 
+  example "It loads configuration file", :force_config_file_reload do
+    expect { run_rake_task }.to change { $CONFIG_LOADED_AT }
+  end
+
   def run_rake_task
     Rake::Task["db:mask"].execute
   end

--- a/spec/support/force_config_file_reload.rb
+++ b/spec/support/force_config_file_reload.rb
@@ -1,0 +1,9 @@
+RSpec.configure do |config|
+  config.before(:each, :force_config_file_reload) do
+    config_path = Rails.root.join("config", "attr_masker.rb").to_s
+    # $" holds names of source files which have been loaded already.
+    # Removing a path from that list causes given file to be loaded
+    # again at next #require call.
+    $".delete(config_path)
+  end
+end

--- a/spec/unit/rake_task_spec.rb
+++ b/spec/unit/rake_task_spec.rb
@@ -6,9 +6,25 @@ require "spec_helper"
 RSpec.describe "db:mask", :suppress_progressbar do
   subject { Rake::Task["db:mask"] }
 
+  let(:config_file_path) do
+    File.expand_path("../dummy/config/attr_masker.rb", __dir__)
+  end
+
   it "loads all application's models eagerly" do
     expect(Rails.application).to receive(:eager_load!)
     subject.execute
     expect(defined? NonPersistedModel).to be_truthy
+  end
+
+  it "loads configuration file if it exists", :force_config_file_reload do
+    allow(File).to receive(:file?).and_call_original
+    allow(File).to receive(:file?).with(config_file_path).and_return(true)
+    expect { subject.execute }.to change { $CONFIG_LOADED_AT }
+  end
+
+  it "works without configuration file", :force_config_file_reload do
+    allow(File).to receive(:file?).and_call_original
+    allow(File).to receive(:file?).with(config_file_path).and_return(false)
+    expect { subject.execute }.not_to change { $CONFIG_LOADED_AT }
   end
 end


### PR DESCRIPTION
If `config/attr_masker.rb` exists, then it is loaded from a Rake task. Fixes #118.